### PR TITLE
Do not overwrite paths with same name

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -110,7 +110,7 @@ class SpecTree:
         routes, tags = {}, {}
         for route in self.backend.find_routes():
             path, parameters = self.backend.parse_path(route)
-            routes[path] = {}
+            routes[path] = routes.get(path, {})
             for method, func in self.backend.parse_func(route):
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -61,8 +61,12 @@ def create_app():
     def bar():
         pass
 
-    @app.route('/lone')
-    def lone():
+    @app.route('/lone', methods=['GET'])
+    def lone_get():
+        pass
+
+    @app.route('/lone', methods=['POST'])
+    def lone_post():
         pass
 
     return app
@@ -80,3 +84,13 @@ def test_spec_bypass_mode():
     app = create_app()
     api_strict.register(app)
     assert get_paths(api_strict.spec) == ['/bar']
+
+
+def test_two_endpoints_with_the_same_path():
+    app = create_app()
+    api.register(app)
+    spec = api.spec
+
+    http_methods = list(spec['paths']['/lone'].keys())
+    http_methods.sort()
+    assert http_methods == ['get', 'post']


### PR DESCRIPTION
Paths with the same name (but different HTTP method) were being overwritten when rendering the spec.

- Adds bugfix and test case
