### PR TITLE
Remove requestBody field for operations that don't have them

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -127,10 +127,13 @@ class SpecTree:
                     'operationID': f'{name}__{method.lower()}',
                     'description': desc or '',
                     'tags': getattr(func, 'tags', []),
-                    'requestBody': parse_request(func),
                     'parameters': parse_params(func, parameters[:]),
                     'responses': parse_resp(func),
                 }
+
+                request_body = parse_request(func)
+                if request_body:
+                    routes[path][method.lower()]['requestBody'] = request_body
 
         spec = {
             'openapi': self.config.OPENAPI_VERSION,

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -25,16 +25,17 @@ def parse_request(func):
     """
     get json spec
     """
-    data = {
-        'content': {
-            'application/json': {
-                'schema': {
-                    '$ref': f'#/components/schemas/{func.json}'
-                    if hasattr(func, 'json') else ''
+    data = {}
+    if hasattr(func, 'json'):
+        data = {
+            'content': {
+                'application/json': {
+                    'schema': {
+                        '$ref': f'#/components/schemas/{func.json}'
+                    }
                 }
             }
         }
-    }
     return data
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,8 +102,7 @@ def test_parse_resp():
 def test_parse_request():
     assert parse_request(demo_func)['content']['application/json']['schema']['$ref'] \
         == '#/components/schemas/DemoModel'
-    assert parse_request(demo_class.demo_method)['content']['application/json']['schema']['$ref'] \
-        == ''
+    assert parse_request(demo_class.demo_method) == {}
 
 
 def test_parse_params():


### PR DESCRIPTION
This PR removes the `requestBody` field from the generated spec for operations that do not define a `json` validation. This matches the behavior from `flaskerk`.

Before:

```json
{
    "paths": {
        "/api/v1/users": {
            "get": {
                "description": "",
                "operationID": "list_users__get",
                "parameters": [],
                "requestBody": {
                    "content": {
                        "application/json": {
                            "schema": {
                                "$ref": ""
                            }
                        }
                    }
                }
            }
        }
    }
}
```

After:

```json
{
    "paths": {
        "/api/v1/users": {
            "get": {
                "description": "",
                "operationID": "list_users__get",
                "parameters": []
            }
        }
    }
}
```

The empty `requestBody` ref was causing the "Try it out" button in swagger-ui to create invalid  HTTP requests (i.e. GET requests with a JSON request body). Here's the curl representation of what it generated:

```bash
curl -X GET "http://localhost:8080/api/v1/users" -H "accept: application/json" -H "Content-Type: application/json"
```

These requests were causing a 400 error in my Flask app, because because when Flask sees the `Content-Type` header it attempts to parse the request body as JSON, and the request body is empty.... because, lol, this is a GET request 😄 .

The [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject) says:

> The request body applicable for this operation. The requestBody is only supported in HTTP methods where the HTTP 1.1 specification RFC7231 has explicitly defined semantics for request bodies. In other cases where the HTTP spec is vague, requestBody SHALL be ignored by consumers.

So I guess that technically this is a swagger-ui bug... or maybe a Flask one... but since the `requestBody` field is optional, there's no reason why SpecTree should include it when it's not valid.
