### PR TITLE
Fixes for operationId, flask/get_json() and more unique path name

### DIFF
--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -143,6 +143,7 @@ class FlaskPlugin(BasePlugin):
 
         before(request, response, req_validation_error, None)
         if req_validation_error:
+            after(request, response, resp_validation_error, None)
             abort(response)
 
         response = make_response(func(*args, **kwargs))

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -111,18 +111,8 @@ class FlaskPlugin(BasePlugin):
         return ''.join(subs), parameters
 
     def request_validation(self, request, query, json, headers, cookies):
-        from werkzeug.exceptions import BadRequest
-
         req_query = request.args or {}
-
-        try:
-            # if content-type is set to application/json but json is passed in below crashes
-            # it is technically intentional by flask, however this can have unexpected results for clients 
-            # that already set these properties incorrectly
-            req_json = request.get_json() or {}
-        except BadRequest:
-            req_json = {}
-
+        req_json = request.get_json(silent=True) or {}
         req_headers = request.headers or {}
         req_cookies = request.cookies or {}
         request.context = Context(
@@ -148,7 +138,7 @@ class FlaskPlugin(BasePlugin):
 
         before(request, response, req_validation_error, None)
         if req_validation_error:
-            after(request, response, resp_validation_error, None)
+            after(request, response, req_validation_error, None)
             abort(response)
 
         response = make_response(func(*args, **kwargs))

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -104,9 +104,9 @@ class FlaskPlugin(BasePlugin):
             parameters.append({
                 'name': variable,
                 'in': 'path',
-                'required': True,
-                'schema': schema,
+                'required': True
             })
+            parameters.update(schema)
 
         return ''.join(subs), parameters
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -101,12 +101,17 @@ class FlaskPlugin(BasePlugin):
             elif converter == 'default':
                 schema = {'type': 'string'}
 
-            parameters.append({
+            param_obj = {
                 'name': variable,
                 'in': 'path',
-                'required': True
-            })
-            parameters.update(schema)
+                'required': True,
+            }
+            if self.config.OPENAPI_VERSION == '2.0':
+                param_obj.update(schema)
+            else:
+                param_obj['schema'] = schema
+
+            parameters.append(param_obj)
 
         return ''.join(subs), parameters
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -177,7 +177,7 @@ class SpecTree:
 
 
         spec = {
-            'swagger' if self.config.OPENAPI_VERSION == '2.0' else 'openapi': self.config.OPENAPI_VERSION,
+            'openapi': self.config.OPENAPI_VERSION,
             'info': {
                 'title': self.config.TITLE,
                 'version': self.config.VERSION,

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -174,7 +174,6 @@ class SpecTree:
                 if request_body:
                     routes[path][method.lower()]['requestBody'] = request_body
 
-
         spec = {
             'openapi': self.config.OPENAPI_VERSION,
             'info': {

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -164,7 +164,7 @@ class SpecTree:
                 routes[path][method.lower()] = {
                     'summary': summary or f'{name} <{method}>',
                     #'operationId': f'{name}__{method.lower()}',
-                    'operationId': f'{method.lower()}_{path}'
+                    'operationId': f'{method.lower()}_{path}',
                     'description': desc or '',
                     'tags': getattr(func, 'tags', []),
                     'parameters': parse_params(func, parameters[:], self.models),

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -163,7 +163,8 @@ class SpecTree:
 
                 routes[path][method.lower()] = {
                     'summary': summary or f'{name} <{method}>',
-                    'operationId': f'{name}__{method.lower()}',
+                    #'operationId': f'{name}__{method.lower()}',
+                    'operationId': f'{method.lower()}_{path}'
                     'description': desc or '',
                     'tags': getattr(func, 'tags', []),
                     'parameters': parse_params(func, parameters[:], self.models),
@@ -173,6 +174,7 @@ class SpecTree:
                 request_body = parse_request(func)
                 if request_body:
                     routes[path][method.lower()]['requestBody'] = request_body
+
 
         spec = {
             'swagger' if self.config.OPENAPI_VERSION == '2.0' else 'openapi': self.config.OPENAPI_VERSION,

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -163,7 +163,6 @@ class SpecTree:
 
                 routes[path][method.lower()] = {
                     'summary': summary or f'{name} <{method}>',
-                    #'operationId': f'{name}__{method.lower()}',
                     'operationId': f'{method.lower()}_{path}',
                     'description': desc or '',
                     'tags': getattr(func, 'tags', []),


### PR DESCRIPTION
This PR includes fixes for following items:
* operationID -> operationId per openapi standard
* operationId value to be more unique (encountered clashes)
* fix for get_json() crash if application/json is set without json body
* also added `after` hook before calling `abort()` on validation error - we return standard json object on any error and needed to modify the default 422 error response in this lib.