### PR TITLE
redoc ui fix

### DIFF
--- a/spectree/plugins/page.py
+++ b/spectree/plugins/page.py
@@ -1,6 +1,6 @@
 PAGES = {
     # https://github.com/Redocly/redoc
-    "redoc": """  # noqa: E501
+    "redoc": """
 <!DOCTYPE html>
 <html>
     <head>
@@ -26,7 +26,7 @@ PAGES = {
         <redoc spec-url='{}'></redoc>
         <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
     </body>
-</html>""",
+</html>""",  # noqa: E501
     # https://swagger.io
     "swagger": """
 <!-- HTML for static distribution bundle build -->


### PR DESCRIPTION
![Screenshot from 2021-01-06 23-59-21](https://user-images.githubusercontent.com/163296/103808038-5f9a1680-507d-11eb-9b25-a0bcf72e1bb2.png)

Text   `# noqa: E501` was showing up in rendered html for _redoc_ documentation.