### PR TITLE
enable view function annotation based type detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Check the [examples](/examples) folder.
 
 If the request doesn't pass the validation, it will return a 422 with JSON error message(ctx, loc, msg, type).
 
+### Opt-in type annotation feature
+This library also supports injection of validated fields into view function arguments along with parameter annotation based type declaration. This works well with linters that can take advantage of typing features like mypy. See examples section below.
+
 ## How To
 
 > How to add summary and description to endpoints?
@@ -65,7 +68,7 @@ Check the [pydantic](https://pydantic-docs.helpmanual.io/usage/schema/) document
 
 Of course. Check the [config](https://spectree.readthedocs.io/en/latest/config.html) document.
 
-You can update the config when init the spectree like: 
+You can update the config when init the spectree like:
 
 ```py
 SpecTree('flask', title='Demo API', version='v1.0', path='doc')
@@ -153,6 +156,25 @@ if __name__ == "__main__":
 
 ```
 
+#### Flask example with type annotation
+
+```python
+# opt in into annotations feature
+api = SpecTree("flask", annotations=True)
+
+
+@app.route('/api/user', methods=['POST'])
+@api.validate(resp=Response(HTTP_200=Message, HTTP_403=None), tags=['api'])
+def user_profile(json: Profile):
+    """
+    verify user profile (summary of this endpoint)
+
+    user's name, user's age, ... (long description)
+    """
+    print(json) # or `request.json`
+    return jsonify(text='it works')
+```
+
 ### Falcon
 
 ```py
@@ -199,6 +221,25 @@ if __name__ == "__main__":
     httpd = simple_server.make_server('localhost', 8000, app)
     httpd.serve_forever()
 
+```
+
+#### Falcon with type annotations
+
+```python
+# opt in into annotations feature
+api = SpecTree("flask", annotations=True)
+
+
+class UserProfile:
+    @api.validate(resp=Response(HTTP_200=Message, HTTP_403=None), tags=['api'])
+    def on_post(self, req, resp, json: Profile):
+        """
+        verify user profile (summary of this endpoint)
+
+        user's name, user's age, ... (long description)
+        """
+        print(req.context.json)  # or `req.media`
+        resp.media = {'text': 'it works'}
 ```
 
 ### Starlette
@@ -251,6 +292,25 @@ if __name__ == "__main__":
     uvicorn.run(app)
 
 ```
+
+#### Starlette example with type annotations
+
+```python
+# opt in into annotations feature
+api = SpecTree("flask", annotations=True)
+
+
+@api.validate(resp=Response(HTTP_200=Message, HTTP_403=None), tags=['api'])
+async def user_profile(request, json=Profile):
+    """
+    verify user profile (summary of this endpoint)
+
+    user's name, user's age, ... (long description)
+    """
+    print(request.context.json)  # or await request.json()
+    return JSONResponse({'text': 'it works'})
+```
+
 
 ## FAQ
 

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -21,6 +21,7 @@ class Config:
         self._SUPPORT_UI = {"redoc", "swagger"}
         self.MODE = "normal"
         self._SUPPORT_MODE = {"normal", "strict", "greedy"}
+        self.ANNOTATIONS = False
 
         self.TITLE = "Service API Document"
         self.VERSION = "0.1"

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -153,6 +153,10 @@ class FalconPlugin(BasePlugin):
         req_validation_error, resp_validation_error = None, None
         try:
             self.request_validation(_req, query, json, headers, cookies)
+            if self.config.ANNOTATIONS:
+                for name in ("query", "json", "headers", "cookies"):
+                    if func.__annotations__.get(name):
+                        kwargs[name] = getattr(_req.context, name)
 
         except ValidationError as err:
             req_validation_error = err

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -147,6 +147,10 @@ class FlaskPlugin(BasePlugin):
         response, req_validation_error, resp_validation_error = None, None, None
         try:
             self.request_validation(request, query, json, headers, cookies)
+            if self.config.ANNOTATIONS:
+                for name in ("query", "json", "headers", "cookies"):
+                    if func.__annotations__.get(name):
+                        kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err
             response = make_response(jsonify(err.errors()), 422)

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -65,6 +65,10 @@ class StarlettePlugin(BasePlugin):
 
         try:
             await self.request_validation(request, query, json, headers, cookies)
+            if self.config.ANNOTATIONS:
+                for name in ("query", "json", "headers", "cookies"):
+                    if func.__annotations__.get(name):
+                        kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err
             response = JSONResponse(err.errors(), 422)

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -155,6 +155,16 @@ class SpecTree:
 
             validation = async_validate if self.backend.ASYNC else sync_validate
 
+            if self.config.ANNOTATIONS:
+                nonlocal query
+                query = func.__annotations__.get("query", query)
+                nonlocal json
+                json = func.__annotations__.get("json", json)
+                nonlocal headers
+                headers = func.__annotations__.get("headers", headers)
+                nonlocal cookies
+                cookies = func.__annotations__.get("cookies", cookies)
+
             # register
             for name, model in zip(
                 ("query", "json", "headers", "cookies"), (query, json, headers, cookies)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,7 +17,11 @@ def test_plugin_spec(api):
 
     assert api.spec["tags"] == [{"name": tag} for tag in ("test", "health", "api")]
 
-    assert get_paths(api.spec) == ["/api/user/{name}", "/ping"]
+    assert get_paths(api.spec) == [
+        "/api/user/{name}",
+        "/api/user_annotated/{name}",
+        "/ping",
+    ]
 
     ping = api.spec["paths"]["/ping"]["get"]
     assert ping["tags"] == ["test", "health"]

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -22,7 +22,7 @@ def api_after_handler(req, resp, err, _):
     resp.headers["X-API"] = "OK"
 
 
-api = SpecTree("flask", before=before_handler, after=after_handler)
+api = SpecTree("flask", before=before_handler, after=after_handler, annotations=True)
 app = Flask(__name__)
 app.config["TESTING"] = True
 
@@ -50,6 +50,20 @@ def user_score(name):
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=request.context.json.name, score=score)
+
+
+@app.route("/api/user_annotated/<name>", methods=["POST"])
+@api.validate(
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=["api", "test"],
+    after=api_after_handler,
+)
+def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
+    score = [randint(0, json.limit) for _ in range(5)]
+    score.sort(reverse=query.order)
+    assert cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return jsonify(name=json.name, score=score)
 
 
 # INFO: ensures that spec is calculated and cached _after_ registering
@@ -83,30 +97,31 @@ def test_flask_validate(client):
     assert resp.headers.get("X-Error") == "Validation Error"
 
     client.set_cookie("flask", "pub", "abcdefg")
-    resp = client.post(
-        "/api/user/flask?order=1",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.headers.get("X-Validation") is None
-    assert resp.headers.get("X-API") == "OK"
-    assert resp.json["name"] == "flask"
-    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
+    for fragment in ("user", "user_annotated"):
+        resp = client.post(
+            f"/api/{fragment}/flask?order=1",
+            data=json.dumps(dict(name="flask", limit=10)),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.json
+        assert resp.headers.get("X-Validation") is None
+        assert resp.headers.get("X-API") == "OK"
+        assert resp.json["name"] == "flask"
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
 
-    resp = client.post(
-        "/api/user/flask?order=0",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+        resp = client.post(
+            f"/api/{fragment}/flask?order=0",
+            data=json.dumps(dict(name="flask", limit=10)),
+            content_type="application/json",
+        )
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
-    resp = client.post(
-        "/api/user/flask?order=0",
-        data="name=flask&limit=10",
-        content_type="application/x-www-form-urlencoded",
-    )
-    assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+        resp = client.post(
+            f"/api/{fragment}/flask?order=0",
+            data="name=flask&limit=10",
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
 
 def test_flask_doc(client):


### PR DESCRIPTION
The current implementation of spectree uses arguments to validate method for declaration of types for query params, request body, cookies and headers and in turn adds a context attribute to request object for all three framework implementations like following:

```python
# flask view implementation
@app.route("/api/user/<name>", methods=["POST"])
@api.validate(
    query=Query,
    json=JSON,
    cookies=Cookies,
    resp=Response(HTTP_200=Resp, HTTP_401=None),
    tags=["api", "test"],
    after=api_after_handler,
)
def user_score(name):
    score = [randint(0, request.context.json.limit) for _ in range(5)]
    score.sort(reverse=request.context.query.order)
    assert request.context.cookies.pub == "abcdefg"
    assert request.cookies["pub"] == "abcdefg"
    return jsonify(name=request.context.json.name, score=score)
```

While this is good, but static linters like mypy complain about `context` attribute missing from flask request object. If view functions itself are annotated with their type and we additionally inject kwargs in view, linters are happy and long `request.context.query.order` access is now just `query.order`. Following is an example of annotated view function:

```python
# flask view implementation with annotation
@app.route("/api/user_annotated/<name>", methods=["POST"])
@api.validate(
    resp=Response(HTTP_200=Resp, HTTP_401=None),
    tags=["api", "test"],
    after=api_after_handler,
)
def user_score_annotated(
    name,
    query: Query,
    json: JSON,
    cookies: Cookies
):
    score = [randint(0, json.limit) for _ in range(5)]
    score.sort(reverse=query.order)
    assert cookies.pub == "abcdefg"
    assert request.cookies["pub"] == "abcdefg"
    return jsonify(name=json.name, score=score)
```

Current implementation is an opt-in feature disabled by default. To opt-in simple instantiate `SpecTree` instance with an additional parameter like following:
```python
api = SpecTree("flask", annotations=True)
```

This feature doesn't change anything if not opted in. Once opted it, user can have a nice API.

I'm willing to discuss the merits, demerits of this approach. It's much closer to _FaskAPI_ usage and since we are already using `pydantic` and annotations inside `spectree`, why stop there.

All tests are in place.

