### PR TITLE
for flask use current_app (recommended way)

### DIFF
--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -1,4 +1,3 @@
-from flask import current_app
 from pydantic import ValidationError
 
 from .base import BasePlugin, Context
@@ -10,6 +9,7 @@ class FlaskPlugin(BasePlugin):
     FORM_MIMETYPE = ("application/x-www-form-urlencoded", "multipart/form-data")
 
     def find_routes(self):
+        from flask import current_app
 
         if self.blueprint_state:
             excludes = [
@@ -39,6 +39,8 @@ class FlaskPlugin(BasePlugin):
         return False
 
     def parse_func(self, route):
+        from flask import current_app
+
         if self.blueprint_state:
             func = self.blueprint_state.app.view_functions[route.endpoint]
         else:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,12 +3,11 @@ import pytest
 from .common import JSON, Cookies, Headers, Query, Resp, get_paths
 from .test_plugin_falcon import api as falcon_api
 from .test_plugin_flask import api as flask_api
-from .test_plugin_flask import flask_ctx  # noqa: F401
 from .test_plugin_starlette import api as starlette_api
 
 
 @pytest.mark.parametrize("api", [flask_api, falcon_api, starlette_api])
-def test_plugin_spec(api, flask_ctx):  # noqa: F811
+def test_plugin_spec(api):
     models = {
         m.__name__: m.schema(ref_template="#/components/schemas/{model}")
         for m in (Query, JSON, Resp, Cookies, Headers)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,11 +3,12 @@ import pytest
 from .common import JSON, Cookies, Headers, Query, Resp, get_paths
 from .test_plugin_falcon import api as falcon_api
 from .test_plugin_flask import api as flask_api
+from .test_plugin_flask import flask_ctx  # noqa: F401
 from .test_plugin_starlette import api as starlette_api
 
 
 @pytest.mark.parametrize("api", [flask_api, falcon_api, starlette_api])
-def test_plugin_spec(api):
+def test_plugin_spec(api, flask_ctx):  # noqa: F811
     models = {
         m.__name__: m.schema(ref_template="#/components/schemas/{model}")
         for m in (Query, JSON, Resp, Cookies, Headers)

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -24,6 +24,13 @@ def api_after_handler(req, resp, err, _):
 
 api = SpecTree("flask", before=before_handler, after=after_handler)
 app = Flask(__name__)
+app.config["TESTING"] = True
+
+
+@pytest.fixture
+def flask_ctx():
+    with app.app_context():
+        yield app
 
 
 @app.route("/ping")

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -27,12 +27,6 @@ app = Flask(__name__)
 app.config["TESTING"] = True
 
 
-@pytest.fixture
-def flask_ctx():
-    with app.app_context():
-        yield app
-
-
 @app.route("/ping")
 @api.validate(headers=Headers, resp=Response(HTTP_200=StrDict), tags=["test", "health"])
 def ping():
@@ -56,6 +50,13 @@ def user_score(name):
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=request.context.json.name, score=score)
+
+
+# INFO: ensures that spec is calculated and cached _after_ registering
+# view functions for validations. This enables tests to access `api.spec`
+# without app_context.
+with app.app_context():
+    api.spec
 
 
 api.register(app)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -38,7 +38,11 @@ def test_register(name, app):
 @pytest.mark.parametrize("name, app", backend_app())
 def test_spec_generate(name, app):
     api = SpecTree(name, app=app, title=f"{name}")
-    spec = api.spec
+    if name == "flask":
+        with app.app_context():
+            spec = api.spec
+    else:
+        spec = api.spec
 
     assert spec["info"]["title"] == name
     assert spec["paths"] == {}
@@ -77,19 +81,23 @@ def create_app():
 def test_spec_bypass_mode():
     app = create_app()
     api.register(app)
-    assert get_paths(api.spec) == ["/foo", "/lone"]
+    with app.app_context():
+        assert get_paths(api.spec) == ["/foo", "/lone"]
 
     app = create_app()
     api_customize_backend.register(app)
-    assert get_paths(api.spec) == ["/foo", "/lone"]
+    with app.app_context():
+        assert get_paths(api.spec) == ["/foo", "/lone"]
 
     app = create_app()
     api_greedy.register(app)
-    assert get_paths(api_greedy.spec) == ["/bar", "/foo", "/lone"]
+    with app.app_context():
+        assert get_paths(api_greedy.spec) == ["/bar", "/foo", "/lone"]
 
     app = create_app()
     api_strict.register(app)
-    assert get_paths(api_strict.spec) == ["/bar"]
+    with app.app_context():
+        assert get_paths(api_strict.spec) == ["/bar"]
 
 
 def test_two_endpoints_with_the_same_path():


### PR DESCRIPTION
- For accessing app use current_app
- ~~For running test use app_context~~
- Enable tests to run outside `app_context` by allowing `api.spec` to be cached for flask app

Earlier spectree was attaching flask app instance to FlaskPlugin itself. While there is still the case of app attaching to spectree instance, but that would need a broader introspection as it's common api/code for flask, starlette and falcon. Flask uses threadlocal and proxy to request and app instance. I'm not very familiar with starlette and falcon so I'll not disturb them.