### PR TITLE
FIX: empty path enpoints leads to Semantic error => clean empty paths

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -209,10 +209,12 @@ class SpecTree:
         for route in self.backend.find_routes():
             path, parameters = self.backend.parse_path(route)
             routes[path] = routes.get(path, {})
+            path_is_empty = True
             for method, func in self.backend.parse_func(route):
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue
 
+                path_is_empty = False
                 name = parse_name(func)
                 summary, desc = parse_comments(func)
                 func_tags = getattr(func, "tags", ())
@@ -235,6 +237,9 @@ class SpecTree:
                 request_body = parse_request(func)
                 if request_body:
                     routes[path][method.lower()]["requestBody"] = request_body
+
+            if path_is_empty:
+                del routes[path]
 
         spec = {
             "openapi": self.config.OPENAPI_VERSION,


### PR DESCRIPTION
* If multiple OAS files are created, paths defined in other scope are empty in current OAS file. If it is an endpoint with path parameter, Semantic error occurs.
* Example: 
```
Semantic error at paths ./v1/foo/bar/{foo_bar_id}
Declared path parameter foo_bar_id needs to be defined as a path parameter at either the path or operation level
```