### PR TITLE
Global security and some changes in security

### DIFF
--- a/spectree/config.py
+++ b/spectree/config.py
@@ -15,6 +15,7 @@ class Config:
     :ivar VERSION: service version
     :ivar DOMAIN: service host domain
     :ivar SECURITY_SCHEMES: OpenAPI `securitySchemes` JSON with list of auth configs
+    :ivar SECURITY: OpenAPI `security` JSON at the global level
     """
 
     def __init__(self, **kwargs):
@@ -33,6 +34,7 @@ class Config:
         self.DOMAIN = None
 
         self.SECURITY_SCHEMES: Optional[List[SecurityScheme]] = None
+        self.SECURITY = {}
 
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Possibility to define security at global (root) level or local (operational) level. It is also possible to override global (root) level by local (operational) level.

> [..] After you have defined the security schemes in the securitySchemes section, you can apply them to the whole API or individual operations by adding the security section on the root level or operation level, respectively. When used on the root level, security applies the specified security schemes globally to all API operations, unless overridden on the operation level. [..]

[Step 2. from [https://swagger.io/docs/specification/authentication/](https://swagger.io/docs/specification/authentication/)]