### PR TITLE
Servers definition

### DIFF
--- a/spectree/config.py
+++ b/spectree/config.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Optional
 
-from .models import SecurityScheme
+from .models import SecurityScheme, Server
 
 
 class Config:
@@ -32,6 +32,7 @@ class Config:
         self.DESCRIPTION = None
         self.VERSION = "0.1"
         self.DOMAIN = None
+        self.SERVERS: Optional[List[Server]] = []
 
         self.SECURITY_SCHEMES: Optional[List[SecurityScheme]] = None
         self.SECURITY = {}

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -143,3 +143,28 @@ class SecurityScheme(BaseModel):
 
     class Config:
         validate_assignment = True
+
+
+class Server(BaseModel):
+    """
+    Servers section of OAS
+    """
+
+    url: str = Field(
+        ...,
+        description="""URL or path of API server
+
+        (may be parametrized with using \"variables\" section - for more information,
+        see: https://swagger.io/docs/specification/api-host-and-base-path/ )""",
+    )
+    description: str = Field(
+        None,
+        description="Custom server description for server URL",
+    )
+    variables: dict = Field(
+        None,
+        description="Variables for customizing server URL",
+    )
+
+    class Config:
+        validate_assignment = True

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -264,6 +264,11 @@ class SpecTree:
             },
         }
 
+        if self.config.SERVERS:
+            spec["servers"] = [
+                server.dict() for server in self.config.SERVERS
+            ]
+
         if self.config.SECURITY:
             spec["security"] = [
                 {security_name: security_config}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ def test_update_config(config):
     assert config.FILENAME == default.FILENAME
     assert config.TITLE == "demo"
     assert config.VERSION == "latest"
+    assert config.SERVERS == []
     assert config.SECURITY_SCHEMES is None
 
     config.update(unknown="missing")


### PR DESCRIPTION
Allows to define servers with url, description and variables as is defined here: https://swagger.io/docs/specification/api-host-and-base-path/