### PR TITLE
Fixed structural error in OAS

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -255,7 +255,9 @@ class SpecTree:
         }
 
         if self.config.SERVERS:
-            spec["servers"] = [server.dict() for server in self.config.SERVERS]
+            spec["servers"] = [
+                server.dict(exclude_none=True) for server in self.config.SERVERS
+            ]
 
         if self.config.SECURITY_SCHEMES:
             spec["components"]["securitySchemes"] = {

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -74,8 +74,8 @@ def test_spec_servers_only(name, app):
     )
 
     assert spec["servers"] == [
-        {"url": server1_url, "description": None, "variables": None},
-        {"url": server2_url, "description": None, "variables": None},
+        {"url": server1_url},
+        {"url": server2_url},
     ]
 
 
@@ -92,14 +92,20 @@ def test_spec_servers_full(name, app):
         ],
     )
 
-    assert spec["servers"] == [
-        {
+    expected = []
+    for server in [server1, server2]:
+        expected_item = {
             "url": server.get("url"),
-            "description": server.get("description", None),
-            "variables": server.get("variables", None),
         }
-        for server in [server1, server2]
-    ]
+        description = server.get("description", None)
+        if description:
+            expected_item["description"] = description
+        variables = server.get("variables", None)
+        if variables:
+            expected_item["variables"] = variables
+        expected.append(expected_item)
+
+    assert spec["servers"] == expected
 
 
 api = SpecTree("flask")


### PR DESCRIPTION
If some item of server is not filled, structural error in OAS occured -> only filled items are generated to OAS specification.

![obrazek](https://user-images.githubusercontent.com/10884140/134317498-a2aa7728-b2c9-4577-9eed-c7995cda7448.png)
