### PR TITLE
Add option for custom validation error status

### DIFF
--- a/spectree/models.py
+++ b/spectree/models.py
@@ -24,8 +24,8 @@ class Tag(BaseModel):
         return self.name
 
 
-class UnprocessableEntityElement(BaseModel):
-    """Model of missing field description."""
+class ValidationErrorElement(BaseModel):
+    """Model of a validation error response element."""
 
     loc: Sequence[str] = Field(
         ...,
@@ -45,10 +45,10 @@ class UnprocessableEntityElement(BaseModel):
     )
 
 
-class UnprocessableEntity(BaseModel):
-    """Model of 422 Unprocessable Entity error."""
+class ValidationError(BaseModel):
+    """Model of a validation error response."""
 
-    __root__: Sequence[UnprocessableEntityElement]
+    __root__: Sequence[ValidationErrorElement]
 
 
 class SecureType(str, Enum):

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -41,7 +41,6 @@ class DocPageAsgi(DocPage):
 
 DOC_CLASS = [x.__name__ for x in (DocPage, OpenAPI, DocPageAsgi, OpenAPIAsgi)]
 
-HTTP_422 = "422 Unprocessable Entity"
 HTTP_500 = "500 Internal Service Response Validation Error"
 
 
@@ -178,7 +177,18 @@ class FalconPlugin(BasePlugin):
             req.context.json = json.parse_obj(media)
 
     def validate(
-        self, func, query, json, headers, cookies, resp, before, after, *args, **kwargs
+        self,
+        func,
+        query,
+        json,
+        headers,
+        cookies,
+        resp,
+        before,
+        after,
+        validation_error_status,
+        *args,
+        **kwargs,
     ):
         # falcon endpoint method arguments: (self, req, resp)
         _self, _req, _resp = args[:3]
@@ -192,7 +202,7 @@ class FalconPlugin(BasePlugin):
 
         except ValidationError as err:
             req_validation_error = err
-            _resp.status = HTTP_422
+            _resp.status = f"{validation_error_status} Validation Error"
             _resp.media = err.errors()
 
         before(_req, _resp, req_validation_error, _self)
@@ -242,7 +252,18 @@ class FalconAsgiPlugin(FalconPlugin):
             req.context.json = json.parse_obj(media)
 
     async def validate(
-        self, func, query, json, headers, cookies, resp, before, after, *args, **kwargs
+        self,
+        func,
+        query,
+        json,
+        headers,
+        cookies,
+        resp,
+        before,
+        after,
+        validation_error_status,
+        *args,
+        **kwargs,
     ):
         # falcon endpoint method arguments: (self, req, resp)
         _self, _req, _resp = args[:3]
@@ -256,7 +277,7 @@ class FalconAsgiPlugin(FalconPlugin):
 
         except ValidationError as err:
             req_validation_error = err
-            _resp.status = HTTP_422
+            _resp.status = f"{validation_error_status} Validation Error"
             _resp.media = err.errors()
 
         before(_req, _resp, req_validation_error, _self)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -137,7 +137,18 @@ class FlaskPlugin(BasePlugin):
         )
 
     def validate(
-        self, func, query, json, headers, cookies, resp, before, after, *args, **kwargs
+        self,
+        func,
+        query,
+        json,
+        headers,
+        cookies,
+        resp,
+        before,
+        after,
+        validation_error_status,
+        *args,
+        **kwargs,
     ):
         from flask import abort, jsonify, make_response, request
 
@@ -150,7 +161,7 @@ class FlaskPlugin(BasePlugin):
                         kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err
-            response = make_response(jsonify(err.errors()), 422)
+            response = make_response(jsonify(err.errors()), validation_error_status)
 
         before(request, response, req_validation_error, None)
         if req_validation_error:

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -47,7 +47,18 @@ class StarlettePlugin(BasePlugin):
         )
 
     async def validate(
-        self, func, query, json, headers, cookies, resp, before, after, *args, **kwargs
+        self,
+        func,
+        query,
+        json,
+        headers,
+        cookies,
+        resp,
+        before,
+        after,
+        validation_error_status,
+        *args,
+        **kwargs,
     ):
         from starlette.responses import JSONResponse
 
@@ -66,13 +77,14 @@ class StarlettePlugin(BasePlugin):
                         kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err
-            response = JSONResponse(err.errors(), 422)
+            response = JSONResponse(err.errors(), validation_error_status)
         except JSONDecodeError as err:
             json_decode_error = err
             self.logger.info(
-                "422 Validation Error", extra={"spectree_json_decode_error": str(err)}
+                f"{validation_error_status} Validation Error",
+                extra={"spectree_json_decode_error": str(err)},
             )
-            response = JSONResponse({"error_msg": str(err)}, 422)
+            response = JSONResponse({"error_msg": str(err)}, validation_error_status)
 
         before(request, response, req_validation_error, instance)
         if req_validation_error or json_decode_error:

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -33,6 +33,9 @@ class SpecTree:
         :meth:`spectree.utils.default_after_handler`
         ``func(req, resp, resp_validation_error, instance)``
         that will be called after the response validation
+    :param validation_error_status: The default response status code to use in the
+        event of a validation error. This value can be overridden for specific endpoints
+        if needed.
     :param kwargs: update default :class:`spectree.config.Config`
     """
 
@@ -43,10 +46,12 @@ class SpecTree:
         app=None,
         before=default_before_handler,
         after=default_after_handler,
+        validation_error_status=422,
         **kwargs,
     ):
         self.before = before
         self.after = after
+        self.validation_error_status = validation_error_status
         self.config = Config(**kwargs)
         self.backend_name = backend_name
         self.backend = backend(self) if backend else PLUGINS[backend_name](self)
@@ -103,6 +108,7 @@ class SpecTree:
         deprecated=False,
         before=None,
         after=None,
+        validation_error_status=None,
     ):
         """
         - validate query, json, headers in request
@@ -122,7 +128,15 @@ class SpecTree:
             specific endpoint
         :param after: :meth:`spectree.utils.default_after_handler` for
             specific endpoint
+        :param validation_error_status: The response status code to use for the
+            specific endpoint, in the event of a validation error. If not specified,
+            the global `validation_error_status` is used instead, defined
+            in :meth:`spectree.spec.SpecTree`.
         """
+        # If the status code for validation errors is not overridden on the level of
+        # the view function, use the globally set status code for validation errors.
+        if not validation_error_status:
+            validation_error_status = self.validation_error_status
 
         def decorate_validation(func):
             # for sync framework
@@ -137,6 +151,7 @@ class SpecTree:
                     resp,
                     before or self.before,
                     after or self.after,
+                    validation_error_status,
                     *args,
                     **kwargs,
                 )
@@ -153,6 +168,7 @@ class SpecTree:
                     resp,
                     before or self.before,
                     after or self.after,
+                    validation_error_status,
                     *args,
                     **kwargs,
                 )

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from functools import wraps
 
 from .config import Config
-from .models import Tag
+from .models import Tag, ValidationError
 from .plugins import PLUGINS
 from .utils import (
     default_after_handler,
@@ -194,6 +194,9 @@ class SpecTree:
                     setattr(validation, name, model_key)
 
             if resp:
+                # Make sure that the endpoint specific status code and data model for
+                # validation errors shows up in the response spec.
+                resp.add_model(validation_error_status, ValidationError, replace=False)
                 for model in resp.models:
                     self._add_model(model=model)
                 validation.resp = resp

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -145,6 +145,86 @@ def test_falcon_validate(client):
     assert resp.headers.get("X-Name") == "sorted random score"
 
 
+class TestFalconValidationErrorResponseStatus:
+    @pytest.fixture
+    def app_client(self, request):
+        api_kwargs = {}
+        if request.param["global_validation_error_status"]:
+            api_kwargs["validation_error_status"] = request.param[
+                "global_validation_error_status"
+            ]
+        api = SpecTree("falcon", **api_kwargs)
+
+        class Ping:
+            name = "health check"
+
+            @api.validate(
+                headers=Headers,
+                tags=["test", "health"],
+                validation_error_status=request.param[
+                    "validation_error_status_override"
+                ],
+            )
+            def on_get(self, req, resp):
+                """summary
+                description
+                """
+                resp.media = {"msg": "pong"}
+
+        app = App()
+        app.add_route("/ping", Ping())
+        api.register(app)
+
+        return testing.TestClient(app)
+
+    @pytest.mark.parametrize(
+        "app_client, expected_status_code",
+        [
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": None,
+                },
+                422,
+                id="default-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": 400,
+                },
+                400,
+                id="default-global-status-with-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 418,
+                    "validation_error_status_override": None,
+                },
+                418,
+                id="overridden-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 400,
+                    "validation_error_status_override": 418,
+                },
+                418,
+                id="overridden-global-status-with-override",
+            ),
+        ],
+        indirect=["app_client"],
+    )
+    def test_validation_error_response_status_code(
+        self, app_client, expected_status_code
+    ):
+        resp = app_client.simulate_request(
+            "GET", "/ping", headers={"Content-Type": "text/plain"}
+        )
+
+        assert resp.status_code == expected_status_code
+
+
 def test_falcon_doc(client):
     resp = client.simulate_get("/apidoc/openapi.json")
     assert resp.json == api.spec

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -145,6 +145,86 @@ def test_falcon_validate(client):
     assert resp.headers.get("X-Name") == "sorted random score"
 
 
+class TestFalconValidationErrorResponseStatus:
+    @pytest.fixture
+    def app_client(self, request):
+        api_kwargs = {}
+        if request.param["global_validation_error_status"]:
+            api_kwargs["validation_error_status"] = request.param[
+                "global_validation_error_status"
+            ]
+        api = SpecTree("falcon-asgi", **api_kwargs)
+
+        class Ping:
+            name = "health check"
+
+            @api.validate(
+                headers=Headers,
+                tags=["test", "health"],
+                validation_error_status=request.param[
+                    "validation_error_status_override"
+                ],
+            )
+            async def on_get(self, req, resp):
+                """summary
+                description
+                """
+                resp.media = {"msg": "pong"}
+
+        app = App()
+        app.add_route("/ping", Ping())
+        api.register(app)
+
+        return testing.TestClient(app)
+
+    @pytest.mark.parametrize(
+        "app_client, expected_status_code",
+        [
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": None,
+                },
+                422,
+                id="default-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": 400,
+                },
+                400,
+                id="default-global-status-with-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 418,
+                    "validation_error_status_override": None,
+                },
+                418,
+                id="overridden-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 400,
+                    "validation_error_status_override": 418,
+                },
+                418,
+                id="overridden-global-status-with-override",
+            ),
+        ],
+        indirect=["app_client"],
+    )
+    def test_validation_error_response_status_code(
+        self, app_client, expected_status_code
+    ):
+        resp = app_client.simulate_request(
+            "GET", "/ping", headers={"Content-Type": "text/plain"}
+        )
+
+        assert resp.status_code == expected_status_code
+
+
 def test_falcon_doc(client):
     resp = client.simulate_get("/apidoc/openapi.json")
     assert resp.json == api.spec

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -142,6 +142,86 @@ def test_flask_validate(client):
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
 
+class TestFlaskValidationErrorResponseStatus:
+    @pytest.fixture
+    def app_client(self, request):
+        api_kwargs = {}
+        if request.param["global_validation_error_status"]:
+            api_kwargs["validation_error_status"] = request.param[
+                "global_validation_error_status"
+            ]
+        api = SpecTree("flask", **api_kwargs)
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        @app.route("/ping")
+        @api.validate(
+            headers=Headers,
+            resp=Response(HTTP_200=StrDict),
+            tags=["test", "health"],
+            validation_error_status=request.param["validation_error_status_override"],
+        )
+        def ping():
+            """summary
+            description"""
+            return jsonify(msg="pong")
+
+        # INFO: ensures that spec is calculated and cached _after_ registering
+        # view functions for validations. This enables tests to access `api.spec`
+        # without app_context.
+        with app.app_context():
+            api.spec
+        api.register(app)
+
+        with app.test_client() as client:
+            yield client
+
+    @pytest.mark.parametrize(
+        "app_client, expected_status_code",
+        [
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": None,
+                },
+                422,
+                id="default-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": 400,
+                },
+                400,
+                id="default-global-status-with-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 418,
+                    "validation_error_status_override": None,
+                },
+                418,
+                id="overridden-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 400,
+                    "validation_error_status_override": 418,
+                },
+                418,
+                id="overridden-global-status-with-override",
+            ),
+        ],
+        indirect=["app_client"],
+    )
+    def test_validation_error_response_status_code(
+        self, app_client, expected_status_code
+    ):
+        resp = app_client.get("/ping")
+
+        assert resp.status_code == expected_status_code
+
+
 def test_flask_doc(client):
     resp = client.get("/apidoc/openapi.json")
     assert resp.json == api.spec

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -136,6 +136,90 @@ def test_flask_validate(client):
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
 
+class TestFlaskValidationErrorResponseStatus:
+    @pytest.fixture
+    def app_client(self, request):
+        api_kwargs = {}
+        if request.param["global_validation_error_status"]:
+            api_kwargs["validation_error_status"] = request.param[
+                "global_validation_error_status"
+            ]
+        api = SpecTree("flask", **api_kwargs)
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        class Ping(MethodView):
+            @api.validate(
+                headers=Headers,
+                resp=Response(HTTP_200=StrDict),
+                tags=["test", "health"],
+                validation_error_status=request.param[
+                    "validation_error_status_override"
+                ],
+            )
+            def get(self):
+                """summary
+                description"""
+                return jsonify(msg="pong")
+
+        app.add_url_rule("/ping", view_func=Ping.as_view("ping"))
+
+        # INFO: ensures that spec is calculated and cached _after_ registering
+        # view functions for validations. This enables tests to access `api.spec`
+        # without app_context.
+        with app.app_context():
+            api.spec
+        api.register(app)
+
+        with app.test_client() as client:
+            yield client
+
+    @pytest.mark.parametrize(
+        "app_client, expected_status_code",
+        [
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": None,
+                },
+                422,
+                id="default-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": None,
+                    "validation_error_status_override": 400,
+                },
+                400,
+                id="default-global-status-with-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 418,
+                    "validation_error_status_override": None,
+                },
+                418,
+                id="overridden-global-status-without-override",
+            ),
+            pytest.param(
+                {
+                    "global_validation_error_status": 400,
+                    "validation_error_status_override": 418,
+                },
+                418,
+                id="overridden-global-status-with-override",
+            ),
+        ],
+        indirect=["app_client"],
+    )
+    def test_validation_error_response_status_code(
+        self, app_client, expected_status_code
+    ):
+        resp = app_client.get("/ping")
+
+        assert resp.status_code == expected_status_code
+
+
 def test_flask_doc(client):
     resp = client.get("/apidoc/openapi.json")
     assert resp.json == api.spec

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,7 +178,7 @@ def test_parse_resp():
     resp_spec = parse_resp(demo_func)
 
     assert resp_spec["422"]["description"] == "Unprocessable Entity"
-    model_path_key = get_model_path_key("spectree.models.UnprocessableEntity")
+    model_path_key = get_model_path_key("spectree.models.ValidationError")
     assert (
         resp_spec["422"]["content"]["application/json"]["schema"]["$ref"]
         == f"#/components/schemas/{model_path_key}"


### PR DESCRIPTION
I think that the hard coded HTTP status code of `422`, that is used for responses in the event of a validation error, makes sense. However there are quite a lot of projects out there that would prefer to use the status of `400`. In some extreme cases `200` is used for most of the responses, and the actual outcome of the request is described in the response payload. (It isn't RESTful at all, but some projects prefer this for some reason.)

The changes in the PR enable the specification of a custom response status code for validation errors, using the `validation_error_status` parameter. It can be configured globally, for all endpoints, but it can be overridden selectively, for specific endpoints too.

