### PR TITLE
Add option for using custom page templates

### DIFF
--- a/spectree/config.py
+++ b/spectree/config.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Optional
 
 from .models import SecurityScheme, Server
+from .page import DEFAULT_PAGE_TEMPLATES
 
 
 class Config:
@@ -16,6 +17,11 @@ class Config:
     :ivar DOMAIN: service host domain
     :ivar SECURITY_SCHEMES: OpenAPI `securitySchemes` JSON with list of auth configs
     :ivar SECURITY: OpenAPI `security` JSON at the global level
+    :ivar PAGE_TEMPLATES: A dictionary of documentation page templates. The key is the
+        name of the template, that is also used in the URL path, while the value is used
+        to render the documentation page content. (Each page template should contain a
+        `{spec_url}` placeholder, that'll be replaced by the actual OpenAPI spec URL in
+        the rendered documentation page.
     """
 
     def __init__(self, **kwargs):
@@ -34,6 +40,8 @@ class Config:
 
         self.SECURITY_SCHEMES: Optional[List[SecurityScheme]] = None
         self.SECURITY = {}
+
+        self.PAGE_TEMPLATES = DEFAULT_PAGE_TEMPLATES
 
         self.logger = logging.getLogger(__name__)
 

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -22,8 +22,6 @@ class Config:
         self.PATH = "apidoc"
         self.FILENAME = "openapi.json"
         self.OPENAPI_VERSION = "3.0.3"
-        self.UI = "redoc"
-        self._SUPPORT_UI = {"redoc", "swagger"}
         self.MODE = "normal"
         self._SUPPORT_MODE = {"normal", "strict", "greedy"}
         self.ANNOTATIONS = False
@@ -70,5 +68,4 @@ class Config:
                 setattr(self, key, value)
                 self.logger.info(f'[✓] Attribute "{key}" has been updated to "{value}"')
 
-        assert self.UI in self._SUPPORT_UI, "unsupported UI"
         assert self.MODE in self._SUPPORT_MODE, "unsupported MODE"

--- a/spectree/page.py
+++ b/spectree/page.py
@@ -1,4 +1,4 @@
-PAGES = {
+DEFAULT_PAGE_TEMPLATES = {
     # https://github.com/Redocly/redoc
     "redoc": """
 <!DOCTYPE html>
@@ -23,7 +23,7 @@ PAGES = {
         </style>
     </head>
     <body>
-        <redoc spec-url='{}'></redoc>
+        <redoc spec-url='{spec_url}'></redoc>
         <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
     </body>
 </html>""",  # noqa: E501
@@ -71,7 +71,7 @@ src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-standalone-preset
         window.onload = function() {{
         // Begin Swagger UI call region
         const ui = SwaggerUIBundle({{
-            url: "{}",
+            url: "{spec_url}",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -5,7 +5,6 @@ from functools import partial
 from pydantic import ValidationError
 
 from .base import BasePlugin
-from .page import PAGES
 
 
 class OpenAPI:
@@ -18,7 +17,7 @@ class OpenAPI:
 
 class DocPage:
     def __init__(self, html, spec_url):
-        self.page = html.format(spec_url)
+        self.page = html.format(spec_url=spec_url)
 
     def on_get(self, req, resp):
         resp.content_type = "text/html"
@@ -78,10 +77,12 @@ class FalconPlugin(BasePlugin):
         self.app.add_route(
             self.config.spec_url, self.OPEN_API_ROUTE_CLASS(self.spectree.spec)
         )
-        for ui in PAGES:
+        for ui in self.config.PAGE_TEMPLATES:
             self.app.add_route(
                 f"/{self.config.PATH}/{ui}",
-                self.DOC_PAGE_ROUTE_CLASS(PAGES[ui], self.config.spec_url),
+                self.DOC_PAGE_ROUTE_CLASS(
+                    self.config.PAGE_TEMPLATES[ui], self.config.spec_url
+                ),
             )
 
     def find_routes(self):

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -1,7 +1,6 @@
 from pydantic import ValidationError
 
 from .base import BasePlugin, Context
-from .page import PAGES
 
 
 class FlaskPlugin(BasePlugin):
@@ -206,9 +205,9 @@ class FlaskPlugin(BasePlugin):
                         )
                     )
 
-                return PAGES[ui].format(spec_url)
+                return self.config.PAGE_TEMPLATES[ui].format(spec_url=spec_url)
 
-            for ui in PAGES:
+            for ui in self.config.PAGE_TEMPLATES:
                 app.add_url_rule(
                     rule=f"/{self.config.PATH}/{ui}",
                     endpoint=f"openapi_{self.config.PATH}_{ui}",
@@ -217,9 +216,11 @@ class FlaskPlugin(BasePlugin):
 
             app.record(lambda state: setattr(self, "blueprint_state", state))
         else:
-            for ui in PAGES:
+            for ui in self.config.PAGE_TEMPLATES:
                 app.add_url_rule(
                     rule=f"/{self.config.PATH}/{ui}",
                     endpoint=f"openapi_{self.config.PATH}_{ui}",
-                    view_func=lambda ui=ui: PAGES[ui].format(self.config.spec_url),
+                    view_func=lambda ui=ui: self.config.PAGE_TEMPLATES[ui].format(
+                        spec_url=self.config.spec_url
+                    ),
                 )

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -6,7 +6,6 @@ from json import JSONDecodeError
 from pydantic import ValidationError
 
 from .base import BasePlugin, Context
-from .page import PAGES
 
 METHODS = {"get", "post", "put", "patch", "delete"}
 Route = namedtuple("Route", ["path", "methods", "func"])
@@ -30,11 +29,11 @@ class StarlettePlugin(BasePlugin):
             lambda request: JSONResponse(self.spectree.spec),
         )
 
-        for ui in PAGES:
+        for ui in self.config.PAGE_TEMPLATES:
             self.app.add_route(
                 f"/{self.config.PATH}/{ui}",
                 lambda request, ui=ui: HTMLResponse(
-                    PAGES[ui].format(self.config.spec_url)
+                    self.config.PAGE_TEMPLATES[ui].format(spec_url=self.config.spec_url)
                 ),
             )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,15 +30,6 @@ def test_update_config(config):
         assert config.unknown
 
 
-def test_update_ui(config):
-    config.update(ui="swagger")
-    assert config.UI == "swagger"
-
-    with pytest.raises(AssertionError) as e:
-        config.update(ui="python")
-    assert "UI" in str(e.value)
-
-
 def test_update_mode(config):
     config.update(mode="greedy")
     assert config.MODE == "greedy"

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -145,92 +145,103 @@ def test_falcon_validate(client):
     assert resp.headers.get("X-Name") == "sorted random score"
 
 
-class TestFalconValidationErrorResponseStatus:
-    @pytest.fixture
-    def app_client(self, request):
-        api_kwargs = {}
-        if request.param["global_validation_error_status"]:
-            api_kwargs["validation_error_status"] = request.param[
-                "global_validation_error_status"
-            ]
-        api = SpecTree("falcon-asgi", **api_kwargs)
+@pytest.fixture
+def test_client_and_api(request):
+    api_args = ["falcon-asgi"]
+    api_kwargs = {}
+    endpoint_kwargs = {
+        "headers": Headers,
+        "resp": Response(HTTP_200=StrDict),
+        "tags": ["test", "health"],
+    }
+    if hasattr(request, "param"):
+        api_args.extend(request.param.get("api_args", ()))
+        api_kwargs.update(request.param.get("api_kwargs", {}))
+        endpoint_kwargs.update(request.param.get("endpoint_kwargs", {}))
 
-        class Ping:
-            name = "health check"
+    api = SpecTree(*api_args, **api_kwargs)
 
-            @api.validate(
-                headers=Headers,
-                tags=["test", "health"],
-                validation_error_status=request.param[
-                    "validation_error_status_override"
-                ],
-            )
-            async def on_get(self, req, resp):
-                """summary
-                description
-                """
-                resp.media = {"msg": "pong"}
+    class Ping:
+        name = "health check"
 
-        app = App()
-        app.add_route("/ping", Ping())
-        api.register(app)
-
-        return testing.TestClient(app)
-
-    @pytest.mark.parametrize(
-        "app_client, expected_status_code",
-        [
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": None,
-                },
-                422,
-                id="default-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": 400,
-                },
-                400,
-                id="default-global-status-with-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 418,
-                    "validation_error_status_override": None,
-                },
-                418,
-                id="overridden-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 400,
-                    "validation_error_status_override": 418,
-                },
-                418,
-                id="overridden-global-status-with-override",
-            ),
-        ],
-        indirect=["app_client"],
-    )
-    def test_validation_error_response_status_code(
-        self, app_client, expected_status_code
-    ):
-        resp = app_client.simulate_request(
-            "GET", "/ping", headers={"Content-Type": "text/plain"}
+        @api.validate(
+            headers=Headers,
+            tags=["test", "health"],
+            validation_error_status=request.param["validation_error_status_override"],
         )
+        async def on_get(self, req, resp):
+            """summary
 
-        assert resp.status_code == expected_status_code
+            description
+            """
+            resp.media = {"msg": "pong"}
+
+    app = App()
+    app.add_route("/ping", Ping())
+    api.register(app)
+
+    return testing.TestClient(app), api
 
 
-def test_falcon_doc(client):
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_status_code",
+    [
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {}},
+            422,
+            id="default-global-status-without-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
+            400,
+            id="default-global-status-with-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
+            418,
+            id="overridden-global-status-without-override",
+        ),
+        pytest.param(
+            {
+                "api_kwargs": {"validation_error_status": 400},
+                "endpoint_kwargs": {"validation_error_status": 418},
+            },
+            418,
+            id="overridden-global-status-with-override",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_validation_error_response_status_code(
+    test_client_and_api, expected_status_code
+):
+    app_client, _ = test_client_and_api
+
+    resp = app_client.simulate_request(
+        "GET", "/ping", headers={"Content-Type": "text/plain"}
+    )
+
+    assert resp.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_doc_pages",
+    [
+        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
+        pytest.param(
+            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
+            ["custom_page"],
+            id="custom-page-templates",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_flask_doc(test_client_and_api, expected_doc_pages):
+    client, api = test_client_and_api
+
     resp = client.simulate_get("/apidoc/openapi.json")
     assert resp.json == api.spec
 
-    resp = client.simulate_get("/apidoc/redoc")
-    assert resp.status_code == 200
-
-    resp = client.simulate_get("/apidoc/swagger")
-    assert resp.status_code == 200
+    for doc_page in expected_doc_pages:
+        resp = client.simulate_get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 200

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -142,95 +142,103 @@ def test_flask_validate(client):
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
 
-class TestFlaskValidationErrorResponseStatus:
-    @pytest.fixture
-    def app_client(self, request):
-        api_kwargs = {}
-        if request.param["global_validation_error_status"]:
-            api_kwargs["validation_error_status"] = request.param[
-                "global_validation_error_status"
-            ]
-        api = SpecTree("flask", **api_kwargs)
-        app = Flask(__name__)
-        app.config["TESTING"] = True
+@pytest.fixture
+def test_client_and_api(request):
+    api_args = ["flask"]
+    api_kwargs = {}
+    endpoint_kwargs = {
+        "headers": Headers,
+        "resp": Response(HTTP_200=StrDict),
+        "tags": ["test", "health"],
+    }
+    if hasattr(request, "param"):
+        api_args.extend(request.param.get("api_args", ()))
+        api_kwargs.update(request.param.get("api_kwargs", {}))
+        endpoint_kwargs.update(request.param.get("endpoint_kwargs", {}))
 
-        @app.route("/ping")
-        @api.validate(
-            headers=Headers,
-            resp=Response(HTTP_200=StrDict),
-            tags=["test", "health"],
-            validation_error_status=request.param["validation_error_status_override"],
-        )
-        def ping():
-            """summary
-            description"""
-            return jsonify(msg="pong")
+    api = SpecTree(*api_args, **api_kwargs)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
 
-        # INFO: ensures that spec is calculated and cached _after_ registering
-        # view functions for validations. This enables tests to access `api.spec`
-        # without app_context.
-        with app.app_context():
-            api.spec
-        api.register(app)
+    @app.route("/ping")
+    @api.validate(**endpoint_kwargs)
+    def ping():
+        """summary
 
-        with app.test_client() as client:
-            yield client
+        description"""
+        return jsonify(msg="pong")
 
-    @pytest.mark.parametrize(
-        "app_client, expected_status_code",
-        [
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": None,
-                },
-                422,
-                id="default-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": 400,
-                },
-                400,
-                id="default-global-status-with-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 418,
-                    "validation_error_status_override": None,
-                },
-                418,
-                id="overridden-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 400,
-                    "validation_error_status_override": 418,
-                },
-                418,
-                id="overridden-global-status-with-override",
-            ),
-        ],
-        indirect=["app_client"],
-    )
-    def test_validation_error_response_status_code(
-        self, app_client, expected_status_code
-    ):
-        resp = app_client.get("/ping")
+    # INFO: ensures that spec is calculated and cached _after_ registering
+    # view functions for validations. This enables tests to access `api.spec`
+    # without app_context.
+    with app.app_context():
+        api.spec
+    api.register(app)
 
-        assert resp.status_code == expected_status_code
+    with app.test_client() as test_client:
+        yield test_client, api
 
 
-def test_flask_doc(client):
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_status_code",
+    [
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {}},
+            422,
+            id="default-global-status-without-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
+            400,
+            id="default-global-status-with-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
+            418,
+            id="overridden-global-status-without-override",
+        ),
+        pytest.param(
+            {
+                "api_kwargs": {"validation_error_status": 400},
+                "endpoint_kwargs": {"validation_error_status": 418},
+            },
+            418,
+            id="overridden-global-status-with-override",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_validation_error_response_status_code(
+    test_client_and_api, expected_status_code
+):
+    app_client, _ = test_client_and_api
+
+    resp = app_client.get("/ping")
+
+    assert resp.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_doc_pages",
+    [
+        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
+        pytest.param(
+            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
+            ["custom_page"],
+            id="custom-page-templates",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_flask_doc(test_client_and_api, expected_doc_pages):
+    client, api = test_client_and_api
+
     resp = client.get("/apidoc/openapi.json")
     assert resp.json == api.spec
 
-    resp = client.get("/apidoc/redoc")
-    assert resp.status_code == 200
-
-    resp = client.get("/apidoc/swagger")
-    assert resp.status_code == 200
+    for doc_page in expected_doc_pages:
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 200
 
 
 """

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -143,91 +143,96 @@ def test_starlette_validate(client):
         assert resp.headers.get("X-Validation") == "Pass"
 
 
-class TestStarletteValidationErrorResponseStatus:
-    @pytest.fixture
-    def app_client(self, request):
-        api_kwargs = {}
-        if request.param["global_validation_error_status"]:
-            api_kwargs["validation_error_status"] = request.param[
-                "global_validation_error_status"
-            ]
-        api = SpecTree("starlette", **api_kwargs)
+@pytest.fixture
+def test_client_and_api(request):
+    api_args = ["starlette"]
+    api_kwargs = {}
+    endpoint_kwargs = {
+        "headers": Headers,
+        "resp": Response(HTTP_200=StrDict),
+        "tags": ["test", "health"],
+    }
+    if hasattr(request, "param"):
+        api_args.extend(request.param.get("api_args", ()))
+        api_kwargs.update(request.param.get("api_kwargs", {}))
+        endpoint_kwargs.update(request.param.get("endpoint_kwargs", {}))
 
-        class Ping(HTTPEndpoint):
-            name = "Ping"
+    api = SpecTree(*api_args, **api_kwargs)
 
-            @api.validate(
-                headers=Headers,
-                resp=Response(HTTP_200=StrDict),
-                tags=["test", "health"],
-                after=method_handler,
-                validation_error_status=request.param[
-                    "validation_error_status_override"
-                ],
-            )
-            def get(self, request):
-                """summary
-                description"""
-                return JSONResponse({"msg": "pong"})
+    class Ping(HTTPEndpoint):
+        name = "Ping"
 
-        app = Starlette(routes=[Route("/ping", Ping)])
-        api.register(app)
+        @api.validate(**endpoint_kwargs)
+        def get(self, request):
+            """summary
 
-        with TestClient(app) as client:
-            yield client
+            description"""
+            return JSONResponse({"msg": "pong"})
 
-    @pytest.mark.parametrize(
-        "app_client, expected_status_code",
-        [
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": None,
-                },
-                422,
-                id="default-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": None,
-                    "validation_error_status_override": 400,
-                },
-                400,
-                id="default-global-status-with-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 418,
-                    "validation_error_status_override": None,
-                },
-                418,
-                id="overridden-global-status-without-override",
-            ),
-            pytest.param(
-                {
-                    "global_validation_error_status": 400,
-                    "validation_error_status_override": 418,
-                },
-                418,
-                id="overridden-global-status-with-override",
-            ),
-        ],
-        indirect=["app_client"],
-    )
-    def test_validation_error_response_status_code(
-        self, app_client, expected_status_code
-    ):
-        resp = app_client.get("/ping")
+    app = Starlette(routes=[Route("/ping", Ping)])
+    api.register(app)
 
-        assert resp.status_code == expected_status_code
+    with TestClient(app) as client:
+        yield client, api
 
 
-def test_starlette_doc(client):
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_status_code",
+    [
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {}},
+            422,
+            id="default-global-status-without-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
+            400,
+            id="default-global-status-with-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
+            418,
+            id="overridden-global-status-without-override",
+        ),
+        pytest.param(
+            {
+                "api_kwargs": {"validation_error_status": 400},
+                "endpoint_kwargs": {"validation_error_status": 418},
+            },
+            418,
+            id="overridden-global-status-with-override",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_validation_error_response_status_code(
+    test_client_and_api, expected_status_code
+):
+    app_client, _ = test_client_and_api
+
+    resp = app_client.get("/ping")
+
+    assert resp.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_doc_pages",
+    [
+        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
+        pytest.param(
+            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
+            ["custom_page"],
+            id="custom-page-templates",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_flask_doc(test_client_and_api, expected_doc_pages):
+    client, api = test_client_and_api
+
     resp = client.get("/apidoc/openapi.json")
     assert resp.json() == api.spec
 
-    resp = client.get("/apidoc/redoc")
-    assert resp.status_code == 200
-
-    resp = client.get("/apidoc/swagger")
-    assert resp.status_code == 200
+    for doc_page in expected_doc_pages:
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 200


### PR DESCRIPTION
This PR adds a `PAGE_TEMPLATE` configuration option, that allows the users of the library to specify custom documentation page templates. If nothing is specified, the default `swagger` and `redoc` templates are used.

The ability to use custom page templates comes in handy if there is a need to customize Swagger UI for example.

I'm aware of the fact that #75 already exists, and it probably tries to achieve the same goal as this PR. But, the big difference between the two solutions is that the changes in this PR, allow the usage of multiple documentation pages, while the solution in #75 only allows a single documentation page when a custom value is specified. Additionally, in #75 the changes are only implemented for the Falcon plugin.