### PR TITLE
Add option to describe path parameters

### DIFF
--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -48,9 +48,11 @@ class BasePlugin:
         """
         raise NotImplementedError
 
-    def parse_path(self, route):
+    def parse_path(self, route, path_parameter_descriptions):
         """
         :param route: API routes
+        :param path_parameter_descriptions: A dictionary of path parameter names and
+            their description.
 
         parse URI path to get the variables in path
         """

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -103,7 +103,7 @@ class FalconPlugin(BasePlugin):
     def parse_func(self, route):
         return route.method_map.items()
 
-    def parse_path(self, route):
+    def parse_path(self, route, path_parameter_descriptions):
         subs, parameters = [], []
         for segment in route.uri_template.strip("/").split("/"):
             matches = self.FIELD_PATTERN.finditer(segment)
@@ -150,12 +150,18 @@ class FalconPlugin(BasePlugin):
                     # no converter specified or customized converters
                     schema = {"type": "string"}
 
+                description = (
+                    path_parameter_descriptions.get(variable, "")
+                    if path_parameter_descriptions
+                    else ""
+                )
                 parameters.append(
                     {
                         "name": variable,
                         "in": "path",
                         "required": True,
                         "schema": schema,
+                        "description": description,
                     }
                 )
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -48,7 +48,7 @@ class FlaskPlugin(BasePlugin):
             for method in route.methods:
                 yield method, func
 
-    def parse_path(self, route):
+    def parse_path(self, route, path_parameter_descriptions):
         from werkzeug.routing import parse_converter_args, parse_rule
 
         subs = []
@@ -105,12 +105,18 @@ class FlaskPlugin(BasePlugin):
             elif converter == "default":
                 schema = {"type": "string"}
 
+            description = (
+                path_parameter_descriptions.get(variable, "")
+                if path_parameter_descriptions
+                else ""
+            )
             parameters.append(
                 {
                     "name": variable,
                     "in": "path",
                     "required": True,
                     "schema": schema,
+                    "description": description,
                 }
             )
 

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -154,7 +154,7 @@ class StarlettePlugin(BasePlugin):
         for method in route.methods or ["GET"]:
             yield method, route.func
 
-    def parse_path(self, route):
+    def parse_path(self, route, path_parameter_descriptions):
         from starlette.routing import compile_path
 
         _, path, variables = compile_path(route.path)
@@ -178,12 +178,18 @@ class StarlettePlugin(BasePlugin):
             elif typ == "str":
                 schema = {"type": "string"}
 
+            description = (
+                path_parameter_descriptions.get(name, "")
+                if path_parameter_descriptions
+                else ""
+            )
             parameters.append(
                 {
                     "name": name,
                     "in": "path",
                     "required": True,
                     "schema": schema,
+                    "description": description,
                 }
             )
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -110,6 +110,7 @@ class SpecTree:
         before=None,
         after=None,
         validation_error_status=None,
+        path_parameter_descriptions=None,
     ):
         """
         - validate query, json, headers in request
@@ -133,6 +134,8 @@ class SpecTree:
             specific endpoint, in the event of a validation error. If not specified,
             the global `validation_error_status` is used instead, defined
             in :meth:`spectree.spec.SpecTree`.
+        :param path_parameter_descriptions: A dictionary of path parameter names and
+            their description.
         """
         # If the status code for validation errors is not overridden on the level of
         # the view function, use the globally set status code for validation errors.
@@ -207,6 +210,7 @@ class SpecTree:
 
             validation.security = security
             validation.deprecated = deprecated
+            validation.path_parameter_descriptions = path_parameter_descriptions
             # register decorator
             validation._decorator = self
             return validation
@@ -230,8 +234,14 @@ class SpecTree:
         routes = defaultdict(dict)
         tags = {}
         for route in self.backend.find_routes():
-            path, parameters = self.backend.parse_path(route)
             for method, func in self.backend.parse_func(route):
+                path_parameter_descriptions = getattr(
+                    func, "path_parameter_descriptions", None
+                )
+                path, parameters = self.backend.parse_path(
+                    route, path_parameter_descriptions
+                )
+
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from copy import deepcopy
 from functools import wraps
 
@@ -226,16 +227,14 @@ class SpecTree:
         """
         generate OpenAPI spec according to routes and decorators
         """
-        routes, tags = {}, {}
+        routes = defaultdict(dict)
+        tags = {}
         for route in self.backend.find_routes():
             path, parameters = self.backend.parse_path(route)
-            routes[path] = routes.get(path, {})
-            path_is_empty = True
             for method, func in self.backend.parse_func(route):
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue
 
-                path_is_empty = False
                 name = parse_name(func)
                 summary, desc = parse_comments(func)
                 func_tags = getattr(func, "tags", ())
@@ -265,9 +264,6 @@ class SpecTree:
                 request_body = parse_request(func)
                 if request_body:
                     routes[path][method.lower()]["requestBody"] = request_body
-
-            if path_is_empty:
-                del routes[path]
 
         spec = {
             "openapi": self.config.OPENAPI_VERSION,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -46,6 +46,7 @@ def test_plugin_spec(api):
 
     assert get_paths(api.spec) == [
         "/api/user/{name}",
+        "/api/user/{name}/address/{address_id}",
         "/api/user_annotated/{name}",
         "/ping",
     ]
@@ -65,12 +66,18 @@ def test_plugin_spec(api):
     )
     assert len(user["responses"]) == 3
 
-    params = user["parameters"]
-    for param in params:
-        if param["in"] == "path":
-            assert param["name"] == "name"
-        elif param["in"] == "query":
-            assert param["name"] == "order"
+    user_address = api.spec["paths"]["/api/user/{name}/address/{address_id}"]["get"]
+    params = user_address["parameters"]
+    assert params[0]["in"] == "path"
+    assert params[0]["name"] == "name"
+    assert params[0]["description"] == "The name that uniquely identifies the user."
+
+    assert params[1]["in"] == "path"
+    assert params[1]["name"] == "address_id"
+    assert params[1]["description"] == ""
+
+    assert params[2]["in"] == "query"
+    assert params[2]["name"] == "order"
 
 
 def test_secure_spec():

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -88,10 +88,25 @@ class UserScoreAnnotated:
         resp.media = {"name": req.context.json.name, "score": score}
 
 
+class UserAddress:
+    name = "user's address"
+
+    @api.validate(
+        query=Query,
+        path_parameter_descriptions={
+            "name": "The name that uniquely identifies the user.",
+            "non-existent-param": "description",
+        },
+    )
+    def on_get(self, req, resp, name, address_id):
+        return None
+
+
 app = App()
 app.add_route("/ping", Ping())
 app.add_route("/api/user/{name}", UserScore())
 app.add_route("/api/user_annotated/{name}", UserScoreAnnotated())
+app.add_route("/api/user/{name}/address/{address_id}", UserAddress())
 api.register(app)
 
 

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -86,6 +86,18 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     return jsonify(name=json.name, score=score)
 
 
+@app.route("/api/user/<name>/address/<address_id>", methods=["GET"])
+@api.validate(
+    query=Query,
+    path_parameter_descriptions={
+        "name": "The name that uniquely identifies the user.",
+        "non-existent-param": "description",
+    },
+)
+def user_address(name, address_id):
+    return None
+
+
 # INFO: ensures that spec is calculated and cached _after_ registering
 # view functions for validations. This enables tests to access `api.spec`
 # without app_context.

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -66,6 +66,18 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     return jsonify(name=json.name, score=score)
 
 
+@app.route("/api/user/<name>/address/<address_id>", methods=["GET"])
+@api.validate(
+    query=Query,
+    path_parameter_descriptions={
+        "name": "The name that uniquely identifies the user.",
+        "non-existent-param": "description",
+    },
+)
+def user_address(name, address_id):
+    return None
+
+
 api.register(app)
 
 flask_app = Flask(__name__)

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -70,12 +70,29 @@ class UserAnnotated(MethodView):
         return jsonify(name=json.name, score=score)
 
 
+class UserAddress(MethodView):
+    @api.validate(
+        query=Query,
+        path_parameter_descriptions={
+            "name": "The name that uniquely identifies the user.",
+            "non-existent-param": "description",
+        },
+    )
+    def get(self, name, address_id):
+        return None
+
+
 app.add_url_rule("/ping", view_func=Ping.as_view("ping"))
 app.add_url_rule("/api/user/<name>", view_func=User.as_view("user"), methods=["POST"])
 app.add_url_rule(
     "/api/user_annotated/<name>",
     view_func=UserAnnotated.as_view("user_annotated"),
     methods=["POST"],
+)
+app.add_url_rule(
+    "/api/user/<name>/address/<address_id>",
+    view_func=UserAddress.as_view("user_address"),
+    methods=["GET"],
 )
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -74,6 +74,17 @@ async def user_score_annotated(request, query: Query, json: JSON, cookies: Cooki
     return JSONResponse({"name": json.name, "score": score})
 
 
+@api.validate(
+    query=Query,
+    path_parameter_descriptions={
+        "name": "The name that uniquely identifies the user.",
+        "non-existent-param": "description",
+    },
+)
+def user_address(request):
+    return None
+
+
 app = Starlette(
     routes=[
         Route("/ping", Ping),
@@ -84,6 +95,11 @@ app = Starlette(
                     "/user",
                     routes=[
                         Route("/{name}", user_score, methods=["POST"]),
+                        Route(
+                            "/{name}/address/{address_id}",
+                            user_address,
+                            methods=["GET"],
+                        ),
                     ],
                 ),
                 Mount(


### PR DESCRIPTION
This PR adds a new `path_parameter_descriptions` parameter to `SpecTree.validate`. This parameter can be used to provide a description of the endpoint's path parameters. The key is interpreted as the name of the path variable, while the value is used as the description.

Example endpoint:
```python
@app.route('/foo/<foo>/bar/<bar>', methods=['GET'])
@api.validate(path_parameter_descriptions={"foo": "Foo's description."})
def foo(foo, bar):
    pass
```
The generated spec:
```json
"/foo/{foo}/bar/{bar}": {
  "get": {
    "summary": "foo <GET>",
    "operationId": "get_/foo/{foo}/bar/{bar}",
    "description": "",
    "tags": [
      
    ],
    "parameters": [
      {
        "name": "foo",
        "in": "path",
        "required": true,
        "schema": {
          "type": "string"
        },
        "description": "Foo's description."
      },
      {
        "name": "bar",
        "in": "path",
        "required": true,
        "schema": {
          "type": "string"
        },
        "description": ""
      }
    ],
    "responses": {
      
    }
  }
}
```

This PR is also a solution for #131. But instead of providing the description of path variables using a pedantic model, it uses just a plain dictionary, since path parameters are already validated by web frameworks.