### PR TITLE
Add option to specify custom descriptions for response status codes.

### DIFF
--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import re
 from hashlib import sha1
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple, Type
 
 from pydantic import BaseModel
 
@@ -207,7 +207,7 @@ def get_model_path_key(model_path: str):
     return model_path_key
 
 
-def get_model_key(model: BaseModel):
+def get_model_key(model: Type[BaseModel]) -> str:
     """
     generate model name prefixed by short hashed path (instead of its path to
     avoid code-structure leaking)


### PR DESCRIPTION
Hello folks!

The default descriptions provided by the library for the HTTP response status codes are usually good enough to understand the reason for a given response. However, there are some status codes whose meaning might not be so clear. A good example for this might be `409`, which indicates that the request could not be processed because of conflict in the current state of the resource. However, the possible reasons for a conflict might be different for different endpoints. For this reason, it would be very useful to have the option to specify custom descriptions for response status codes.

This PR adds the option to specify response models on endpoints together with a custom description.

```python
@app.route('/foo', methods=['GET'])
@api.validate(
    resp=Response(
        HTTP_200=Message,
        HTTP_201=(Message, "Custom description."),
    )
)
def foo():
    pass
```
The example above results in the following OpenAPI spec output:
```json
"/foo": {
  "get": {
    "summary": "foo <GET>",
    "operationId": "get_/foo",
    "description": "",
    "tags": [
      
    ],
    "parameters": [
      
    ],
    "responses": {
      "200": {
        "description": "OK",
        "content": {
          "application/json": {
            "schema": {
              "$ref": "#/components/schemas/b28b7af.Message"
            }
          }
        }
      },
      "201": {
        "description": "Custom description.",
        "content": {
          "application/json": {
            "schema": {
              "$ref": "#/components/schemas/b28b7af.Message"
            }
          }
        }
      },
      "422": {
        "description": "Unprocessable Entity",
        "content": {
          "application/json": {
            "schema": {
              "$ref": "#/components/schemas/6a07bef.ValidationError"
            }
          }
        }
      }
    }
  }
},

```