### PR TITLE
Form data support

### DIFF
--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -138,17 +138,3 @@ if __name__ == "__main__":
     print("Swagger documentation: http://localhost:8000/apidoc/swagger\n"
           "Redoc documentation: http://localhost:8000/apidoc/redoc")
     httpd.serve_forever()
-    """
-    Привет!
-    Попытался сделать поддержку загрузки файлов через Swagger, и у меня даже кое-как получилось, но в силу своей
-    неопытности у меня появилось много проблем и вопросов:
-    Проблемы:
-    Поменять тип поля в pydantic получилось только с помощью Field(type='file').
-    
-    Вопросы:
-    1. Как динамически понять тип данных ожидаемого запроса в функции "parse_request" (для генерации соответсвующей формы в Swagger/Redoc)?
-    К примеру, в модуле 'drf-yasg' они парсят объекты класса if view explicitly sets its parser classes to include only form parsers
-    [Ссылка](https://github.com/axnsan12/drf-yasg/blob/master/src/drf_yasg/utils.py#L366)
-    2. Возможно ли понять "content_length" потока данных без его считывания? Нужен ли вообще этот параметр ?
-    3. Если файл слишком большой, куда его сохранять во время валидации? BufferIO, TemporaryFile ?
-    """

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from random import random
 from wsgiref import simple_server

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -116,15 +116,15 @@ class FileUpload:
     file-handling demo
     """
 
-    @api.validate(form_data=File, resp=Response(HTTP_200=FileResp))
+    @api.validate(form_data=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
     def on_post(self, req, resp):
         """
         post multipart/form-data demo
 
         demo for 'form_data'
         """
-        img_data = req.context.form_data.file
-        resp.media = {"filename": img_data.filename, "content_length": img_data.content_length}
+        file_data = req.context.form_data.file
+        resp.media = {"filename": file_data.filename, "content_length": file_data.content_length}
 
 
 if __name__ == "__main__":
@@ -138,3 +138,17 @@ if __name__ == "__main__":
     print("Swagger documentation: http://localhost:8000/apidoc/swagger\n"
           "Redoc documentation: http://localhost:8000/apidoc/redoc")
     httpd.serve_forever()
+    """
+    Привет!
+    Попытался сделать поддержку загрузки файлов через Swagger, и у меня даже кое-как получилось, но в силу своей
+    неопытности у меня появилось много проблем и вопросов:
+    Проблемы:
+    Поменять тип поля в pydantic получилось только с помощью Field(type='file').
+    
+    Вопросы:
+    1. Как динамически понять тип данных ожидаемого запроса в функции "parse_request" (для генерации соответсвующей формы в Swagger/Redoc)?
+    К примеру, в модуле 'drf-yasg' они парсят объекты класса if view explicitly sets its parser classes to include only form parsers
+    [Ссылка](https://github.com/axnsan12/drf-yasg/blob/master/src/drf_yasg/utils.py#L366)
+    2. Возможно ли понять "content_length" потока данных без его считывания? Нужен ли вообще этот параметр?
+    
+    """

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -56,7 +56,7 @@ class Data(BaseModel):
 
 class File(BaseModel):
     uid: str
-    file: models.BaseFile = Field(..., type='file')
+    file: models.BaseFile
 
 
 class FileResp(BaseModel):
@@ -149,6 +149,6 @@ if __name__ == "__main__":
     1. Как динамически понять тип данных ожидаемого запроса в функции "parse_request" (для генерации соответсвующей формы в Swagger/Redoc)?
     К примеру, в модуле 'drf-yasg' они парсят объекты класса if view explicitly sets its parser classes to include only form parsers
     [Ссылка](https://github.com/axnsan12/drf-yasg/blob/master/src/drf_yasg/utils.py#L366)
-    2. Возможно ли понять "content_length" потока данных без его считывания? Нужен ли вообще этот параметр?
-    
+    2. Возможно ли понять "content_length" потока данных без его считывания? Нужен ли вообще этот параметр ?
+    3. Если файл слишком большой, куда его сохранять во время валидации? BufferIO, TemporaryFile ?
     """

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -41,7 +41,7 @@ class Data(BaseModel):
 
 class File(BaseModel):
     uid: str
-    file: models.BaseFile = Field(..., type='file')
+    file: models.BaseFile
 
 
 class FileResp(BaseModel):

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -5,7 +5,7 @@ from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
 from pydantic import BaseModel, Field
 
-from spectree import Response, SpecTree
+from spectree import Response, SpecTree, models
 
 app = Flask(__name__)
 api = SpecTree("flask")
@@ -37,6 +37,16 @@ class Data(BaseModel):
                 "vip": True,
             }
         }
+
+
+class File(BaseModel):
+    uid: str
+    file: models.BaseFile = Field(..., type='file')
+
+
+class FileResp(BaseModel):
+    filename: str
+    content_length: int
 
 
 class Language(str, Enum):
@@ -87,6 +97,18 @@ def with_code_header():
     query with ``http POST :8000/api/header Lang:zh-CN Cookie:key=hello``
     """
     return jsonify(language=request.context.headers.Lang), 203, {"X": 233}
+
+
+@app.route("/api/upload-file", methods=["POST"])
+@api.validate(form_data=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
+def with_file():
+    """
+    post multipart/form-data demo
+
+    demo for 'form_data'
+    """
+    file_data = request.context.form_data.file
+    return jsonify(filename=file_data.filename, content_length=file_data.content_length)
 
 
 class UserAPI(MethodView):

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -174,7 +174,7 @@ class BaseFile(BaseModel):
     filename: str
     name: str
     content_length: int
-    mimetype: str
+    content_type: str
     stream: bytes
 
     class Config:

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -176,3 +176,8 @@ class BaseFile(BaseModel):
     content_length: int
     mimetype: str
     stream: bytes
+
+    class Config:
+        schema_extra = {
+            'type': 'file'
+        }

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -171,17 +171,6 @@ class Server(BaseModel):
 
 
 class BaseFile(BaseModel):
-    """
-    Inherit your model from this model and explicitly specify the field type as in the example below,
-    so that it will be possible to load the image with Swagger.
-
-    Example:
-        >>> from pydantic import BaseModel, Field
-        >>> from spectree.models import BaseFile
-        >>> class Image(BaseModel):
-        ...     image: BaseFile = Field(type='file')
-        ...     likes: int
-    """
     filename: str
     name: str
     content_length: int

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -168,3 +168,22 @@ class Server(BaseModel):
 
     class Config:
         validate_assignment = True
+
+
+class BaseFile(BaseModel):
+    """
+    Inherit your model from this model and explicitly specify the field type as in the example below,
+    so that it will be possible to load the image with Swagger.
+
+    Example:
+        >>> from pydantic import BaseModel, Field
+        >>> from spectree.models import BaseFile
+        >>> class Image(BaseModel):
+        ...     image: BaseFile = Field(type='file')
+        ...     likes: int
+    """
+    filename: str
+    name: str
+    content_length: int
+    mimetype: str
+    stream: bytes

--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -1,7 +1,7 @@
 import logging
 from collections import namedtuple
 
-Context = namedtuple("Context", ["query", "json", "headers", "cookies"])
+Context = namedtuple("Context", ["query", "json", "form_data", "headers", "cookies"])
 
 
 class BasePlugin:

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -188,16 +188,17 @@ class FalconPlugin(BasePlugin):
                 # Compare first part of content_type with media types
                 if part.content_type.split('/')[0] == 'text':
                     data[part.name] = part.text
-                elif part.content_type.split('/')[0] in ['image', 'application']:
+                elif part.content_type.split('/')[0] in ['image', 'application', 'audio']:
                     data[part.name] = {
                         "filename": part.filename,
                         "name": part.name,
-                        "content_length": len(part.data),
+                        # "content_length": len(part.data),  # FIXME: raises error if file is too big
+                        "content_length": 0,  # TODO: replace placeholder
                         "mimetype": part.content_type,
-                        "stream": part.data
+                        "stream": part.stream.read()
                     }
                 # TODO: add support for other media types?
-                # TODO: handle unsupported media types?
+                # TODO: or handle unsupported media types?
             req.context.form_data = form_data.parse_obj(data)
 
     def validate(

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -167,7 +167,7 @@ class FalconPlugin(BasePlugin):
 
         return f'/{"/".join(subs)}', parameters
 
-    def request_validation(self, req, query, json, headers, cookies):
+    def request_validation(self, req, query, json, form_data, headers, cookies):
         if query:
             req.context.query = query.parse_obj(req.params)
         if headers:
@@ -188,6 +188,7 @@ class FalconPlugin(BasePlugin):
         func,
         query,
         json,
+        form_data,
         headers,
         cookies,
         resp,
@@ -201,7 +202,7 @@ class FalconPlugin(BasePlugin):
         _self, _req, _resp = args[:3]
         req_validation_error, resp_validation_error = None, None
         try:
-            self.request_validation(_req, query, json, headers, cookies)
+            self.request_validation(_req, query, json, form_data, headers, cookies)
             if self.config.ANNOTATIONS:
                 for name in ("query", "json", "headers", "cookies"):
                     if func.__annotations__.get(name):
@@ -242,7 +243,7 @@ class FalconAsgiPlugin(FalconPlugin):
     OPEN_API_ROUTE_CLASS = OpenAPIAsgi
     DOC_PAGE_ROUTE_CLASS = DocPageAsgi
 
-    async def request_validation(self, req, query, json, headers, cookies):
+    async def request_validation(self, req, query, json, form_data, headers, cookies):
         if query:
             req.context.query = query.parse_obj(req.params)
         if headers:
@@ -263,6 +264,7 @@ class FalconAsgiPlugin(FalconPlugin):
         func,
         query,
         json,
+        form_data,
         headers,
         cookies,
         resp,
@@ -276,7 +278,7 @@ class FalconAsgiPlugin(FalconPlugin):
         _self, _req, _resp = args[:3]
         req_validation_error, resp_validation_error = None, None
         try:
-            await self.request_validation(_req, query, json, headers, cookies)
+            await self.request_validation(_req, query, json, form_data, headers, cookies)
             if self.config.ANNOTATIONS:
                 for name in ("query", "json", "headers", "cookies"):
                     if func.__annotations__.get(name):

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -182,6 +182,23 @@ class FalconPlugin(BasePlugin):
             media = None
         if json:
             req.context.json = json.parse_obj(media)
+        elif form_data:
+            data = {}
+            for part in media:
+                # Compare first part of content_type with media types
+                if part.content_type.split('/')[0] == 'text':
+                    data[part.name] = part.text
+                elif part.content_type.split('/')[0] in ['image', 'application']:
+                    data[part.name] = {
+                        "filename": part.filename,
+                        "name": part.name,
+                        "content_length": len(part.data),
+                        "mimetype": part.content_type,
+                        "stream": part.data
+                    }
+                # TODO: add support for other media types?
+                # TODO: handle unsupported media types?
+            req.context.form_data = form_data.parse_obj(data)
 
     def validate(
         self,

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -182,9 +182,9 @@ class FalconPlugin(BasePlugin):
             media = None
         if json:
             req.context.json = json.parse_obj(media)
-        elif form_data:
+        elif form_data and media is not None:
             data = {}
-            for part in media:
+            for part in media:  # TODO: add support for falcon 2.0 (media is always None for 'multipart/form-data')
                 # Compare first part of content_type with media types
                 if part.content_type.split('/')[0] == 'text':
                     data[part.name] = part.text
@@ -193,12 +193,12 @@ class FalconPlugin(BasePlugin):
                         "filename": part.filename,
                         "name": part.name,
                         # "content_length": len(part.data),  # FIXME: raises error if file is too big
-                        "content_length": 0,  # TODO: replace placeholder
+                        "content_length": 0,  # TODO: replace placeholder with something that will work
                         "mimetype": part.content_type,
                         "stream": part.stream.read()
                     }
                 # TODO: add support for other media types?
-                # TODO: or handle unsupported media types?
+                # TODO: OR handle unsupported media types?
             req.context.form_data = form_data.parse_obj(data)
 
     def validate(

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -193,9 +193,10 @@ class FalconPlugin(BasePlugin):
                         "filename": part.filename,
                         "name": part.name,
                         # "content_length": len(part.data),  # FIXME: raises error if file is too big
+                        # sadly, BufferedReader don't have 'tell' method
                         "content_length": 0,  # TODO: replace placeholder with something that will work
-                        "mimetype": part.content_type,
-                        "stream": part.stream.read()
+                        "content_type": part.content_type,
+                        "stream": part.stream.read(),
                     }
                 # TODO: add support for other media types?
                 # TODO: OR handle unsupported media types?

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -122,7 +122,7 @@ class FlaskPlugin(BasePlugin):
 
         return "".join(subs), parameters
 
-    def request_validation(self, request, query, json, headers, cookies):
+    def request_validation(self, request, query, json, form_data, headers, cookies):
         req_query = request.args or {}
         if request.mimetype in self.FORM_MIMETYPE:
             req_json = request.form or {}
@@ -146,6 +146,7 @@ class FlaskPlugin(BasePlugin):
         func,
         query,
         json,
+        form_data,
         headers,
         cookies,
         resp,
@@ -159,7 +160,7 @@ class FlaskPlugin(BasePlugin):
 
         response, req_validation_error, resp_validation_error = None, None, None
         try:
-            self.request_validation(request, query, json, headers, cookies)
+            self.request_validation(request, query, json, form_data, headers, cookies)
             if self.config.ANNOTATIONS:
                 for name in ("query", "json", "headers", "cookies"):
                     if func.__annotations__.get(name):

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -126,10 +126,7 @@ class FlaskPlugin(BasePlugin):
         req_query = request.args or {}
         if request.mimetype in self.FORM_MIMETYPE:
             req_json = request.form or {}
-            # if request.files:
-            #     req_json = dict(
-            #         list(request.form.items()) + list(request.files.items())
-            #     )
+
             for key, file in request.files.items():  # TODO: My eyes bleed. How to improve this loop?
                 req_json = dict(
                     list(request.form.items())
@@ -137,9 +134,9 @@ class FlaskPlugin(BasePlugin):
                 req_json.update({key: {
                     "filename": file.filename,
                     "name": file.name,
-                    "content_length": file.content_length,  # FIXME: always 0
-                    "mimetype": file.content_type,
-                    "stream": file.stream.read()
+                    "content_type": file.content_type,
+                    "stream": file.stream.read(),
+                    "content_length": file.stream.tell(),
                 }})
         else:
             req_json = request.get_json(silent=True) or {}

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -37,7 +37,7 @@ class StarlettePlugin(BasePlugin):
                 ),
             )
 
-    async def request_validation(self, request, query, json, headers, cookies):
+    async def request_validation(self, request, query, json, form_data, headers, cookies):
         request.context = Context(
             query.parse_obj(request.query_params) if query else None,
             json.parse_raw(await request.body() or "{}") if json else None,
@@ -50,6 +50,7 @@ class StarlettePlugin(BasePlugin):
         func,
         query,
         json,
+        form_data,
         headers,
         cookies,
         resp,
@@ -69,7 +70,7 @@ class StarlettePlugin(BasePlugin):
         req_validation_error = resp_validation_error = json_decode_error = None
 
         try:
-            await self.request_validation(request, query, json, headers, cookies)
+            await self.request_validation(request, query, json, form_data, headers, cookies)
             if self.config.ANNOTATIONS:
                 for name in ("query", "json", "headers", "cookies"):
                     if func.__annotations__.get(name):

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -49,9 +49,9 @@ class StarlettePlugin(BasePlugin):
                     data[key] = {
                         "filename": value.filename,
                         "name": key,
-                        "content_length": 0,  # TODO: replace placeholder with something that will work
-                        "mimetype": value.content_type,
-                        "stream": value.file.read()  # FIXME: takes a long time if the file is large
+                        "content_type": value.content_type,
+                        "stream": value.file.read(),  # FIXME: takes a long time if the file is large
+                        "content_length": value.file.tell(),
                     }
                 else:
                     data[key] = value

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -145,6 +145,8 @@ class SpecTree:
             validation_error_status = self.validation_error_status
 
         if json and form_data:
+            # TODO: how to resolve conflict between json and form_data?
+            # TODO: Maybe replace 'form_data' with 'request_body' as it is done in 'drf-yasg'?
             raise ValueError("You should provide either 'json' or 'form_data'.")
 
         def decorate_validation(func):

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -102,6 +102,7 @@ class SpecTree:
         query=None,
         json=None,
         headers=None,
+        form_data=None,
         cookies=None,
         resp=None,
         tags=(),
@@ -120,6 +121,7 @@ class SpecTree:
 
         :param query: `pydantic.BaseModel`, query in uri like `?name=value`
         :param json: `pydantic.BaseModel`, JSON format request body
+        :param form_data: `pydantic.BaseModel`, form-data request body
         :param headers: `pydantic.BaseModel`, if you have specific headers
         :param cookies: `pydantic.BaseModel`, if you have cookies for this route
         :param resp: `spectree.Response`
@@ -142,6 +144,9 @@ class SpecTree:
         if not validation_error_status:
             validation_error_status = self.validation_error_status
 
+        if json and form_data:
+            raise ValueError("You should provide either 'json' or 'form_data'.")
+
         def decorate_validation(func):
             # for sync framework
             @wraps(func)
@@ -150,6 +155,7 @@ class SpecTree:
                     func,
                     query,
                     json,
+                    form_data,
                     headers,
                     cookies,
                     resp,
@@ -167,6 +173,7 @@ class SpecTree:
                     func,
                     query,
                     json,
+                    form_data,
                     headers,
                     cookies,
                     resp,
@@ -184,6 +191,8 @@ class SpecTree:
                 query = func.__annotations__.get("query", query)
                 nonlocal json
                 json = func.__annotations__.get("json", json)
+                nonlocal form_data
+                form_data = func.__annotations__.get("form_data", form_data)
                 nonlocal headers
                 headers = func.__annotations__.get("headers", headers)
                 nonlocal cookies
@@ -191,7 +200,7 @@ class SpecTree:
 
             # register
             for name, model in zip(
-                ("query", "json", "headers", "cookies"), (query, json, headers, cookies)
+                ("query", "json", "form_data", "headers", "cookies"), (query, json, form_data, headers, cookies)
             ):
                 if model is not None:
                     model_key = self._add_model(model=model)

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -59,6 +59,14 @@ def parse_request(func):
                 }
             }
         }
+    elif hasattr(func, "form_data"):
+        data = {
+            "content": {
+                "multipart/form-data": {
+                    "schema": {"$ref": f"#/components/schemas/{func.form_data}"}
+                }
+            }
+        }
     return data
 
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -1,5 +1,7 @@
 from random import randint
 
+import falcon
+
 try:
     from falcon import App
 except ImportError:
@@ -256,3 +258,13 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     for doc_page in expected_doc_pages:
         resp = client.simulate_get(f"/apidoc/{doc_page}")
         assert resp.status_code == 200
+
+
+def test_error_json_with_form_data(test_client_and_api):
+    with pytest.raises(Exception) as e_info:
+        class AdminClass:
+            @api.validate(json=JSON, form_data=JSON)
+            def on_post(self, req, resp, name):
+                pass
+
+    assert e_info.value.args[0] == "You should provide either 'json' or 'form_data'."


### PR DESCRIPTION
Hi everyone!

This PR shows an example of support for uploading files via Swagger.

Usage example with ```werkzeug.datastructures.FileStorage``` (Flask):

```python3
from werkzeug.datastructures import FileStorage
from pydantic import BaseModel
from spectree import models

class File(BaseModel):
    uid: str
    file: models.BaseFile

@api.validate(form_data=File)
def with_file():
    file_dict = request.context.form_data.file.dict()
    file = FileStorage(**file_dict)
    return jsonify()
...
```

## Issues:
1. If uploading files using the Falcon framework plugin - ```content_length``` is always 0.

## Questions:
1. How to get ```content_length``` from ```falcon.cyutil.reader.BufferedReader``` object?
2. Initially ```SpecTree.validate``` only accepts ```json``` parameter to define request body. Would it be correct to separate request body schemas for ```multipart/form-data``` and ```application/json``` content types with different parameters (```json``` and ```from_data```) like I did or is there a cleaner way to do it?</br>
For example, the 'drf-yasg' module uses a generic ```request_body``` parameter for both content types.
To define the content type **'drf-yasg'** parses the view class object and if a view include only form parsers - swagger will support file upload.
[**drf-yasg implementation**](https://github.com/axnsan12/drf-yasg/blob/master/src/drf_yasg/utils.py#L366)</br>
Wouldn't it make sense to make a generic ```request_body``` parameter like in **'drf-yasg**' and understand expected request content type of the request body by some flag for example?