### PR TITLE
Add description argument to Response.add_model()

### DIFF
--- a/spectree/response.py
+++ b/spectree/response.py
@@ -55,7 +55,11 @@ class Response:
                 self.code_descriptions[code] = description
 
     def add_model(
-        self, code: int, model: Type[BaseModel], replace: bool = True
+        self,
+        code: int,
+        model: Type[BaseModel],
+        replace: bool = True,
+        description: Optional[str] = None,
     ) -> None:
         """Add data *model* for the specified status *code*.
 
@@ -64,10 +68,14 @@ class Response:
         :param replace: If `True` and a data *model* already exists for the given
             status *code* it will be replaced, if `False` the existing data *model*
             will be retained.
+        :param description: The description string for the code.
         """
         if not replace and self.find_model(code):
             return
-        self.code_models[f"HTTP_{code}"] = model
+        code_name = f"HTTP_{code}"
+        self.code_models[code_name] = model
+        if description:
+            self.code_descriptions[code_name] = description
 
     def has_model(self) -> bool:
         """


### PR DESCRIPTION
After a nice PR #182 I began using that feature, but found myself in a position where I had to use the `Response.add_model()` method, which did not support adding descriptions through the tuple-notation or otherwise. I have added this functionality in this PR.

It would have been nice if the `replace` argument were defined as keyword-only (`*, replace: bool = True`) because to me, the logical place to add the description is as a positional argument directly after `model`. Unfortunately, at this time that will break existing code using the `replace` argument as a positional one, since Python will happily accept False as "description", then ignore that as code description and replace the existing model despite the developer intending to not do so.

I would have liked to explicitly check `if description is not None` because the current check also yields True for the empty string (for which there probably is no use case, but hey, if someone explicitly passes it?) but the code in the constructor also just checks the boolean equivalent so I wanted to keep it consistent.