### PR TITLE
Support skipping validation and returning models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,6 @@ lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
 	flake8 ${SOURCE_FILES} --count --show-source --statistics
-	mypy --install-types --non-interactive ${SOURCE_FILES}
+	mypy --install-types --non-interactive spectree
 
 .PHONY: test doc

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ publish: package
 	twine upload dist/*
 
 format:
+	pip install black isort autoflake
 	autoflake --in-place --recursive --remove-all-unused-imports --ignore-init-module-imports ${SOURCE_FILES}
 	isort --project=spectree ${SOURCE_FILES}
 	black ${SOURCE_FILES}
 
 lint:
+	pip install black isort flake8 mypy
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
 	flake8 ${SOURCE_FILES} --count --show-source --statistics

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,11 @@ publish: package
 	twine upload dist/*
 
 format:
-	pip install black isort autoflake
 	autoflake --in-place --recursive --remove-all-unused-imports --ignore-init-module-imports ${SOURCE_FILES}
 	isort --project=spectree ${SOURCE_FILES}
 	black ${SOURCE_FILES}
 
 lint:
-	pip install black isort flake8 mypy
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
 	flake8 ${SOURCE_FILES} --count --show-source --statistics

--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ This library provides `before` and `after` hooks to do these. Check the [doc](ht
 
 You can change the `validation_error_status` in SpecTree (global) or a specific endpoint (local). This also takes effect in the OpenAPI documentation.
 
+> How can I skip the validation?
+
+Add `skip_validation=True` to the decorator.  
+
+```py
+@api.validate(json=Profile, resp=Response(HTTP_200=Message, HTTP_403=None), skip_validation=True)
+```
+
+> How can I return my model directly?
+
+Yes, returning an instance of `BaseModel` will assume the model is valid and bypass spectree's validation and automatically call `.dict()` on the model.  
+
 ## Demo
 
 Try it with `http post :8000/api/user name=alice age=18`. (if you are using `httpie`)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ Add `skip_validation=True` to the decorator.
 
 Yes, returning an instance of `BaseModel` will assume the model is valid and bypass spectree's validation and automatically call `.dict()` on the model.  
 
+For starlette you should return a `PydanticResponse`:
+```py
+from spectree.plugins.starlette_plugin import PydanticResponse
+
+return PydanticResponse(MyModel)
+```
+
 ## Demo
 
 Try it with `http post :8000/api/user name=alice age=18`. (if you are using `httpie`)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -190,16 +190,19 @@ class FlaskPlugin(BasePlugin):
 
         result = func(*args, **kwargs)
 
+        status = 200
+        rest = []
         if resp and isinstance(result, tuple) and isinstance(result[0], BaseModel):
             if len(result) > 1:
-                result = result[0].dict(), *result[1:]
+                model, status, *rest = result
             else:
-                result = (result[0].dict(),)
+                model = result[0]
+        else:
+            model = result
 
+        if isinstance(model, resp.find_model(status)):
             skip_validation = True
-        elif resp and isinstance(result, BaseModel):
-            result = result.dict()
-            skip_validation = True
+            result = (model.dict(), status, *rest)
 
         response = make_response(result)
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -190,22 +190,12 @@ class FlaskPlugin(BasePlugin):
 
         result = func(*args, **kwargs)
 
-        # If we return a tuple of a Pydantic Model and a status then confirm
-        # that model matches that status and further skip validation
         if resp and isinstance(result, tuple) and isinstance(result[0], BaseModel):
-            status_code = result[1]
-            if isinstance(result, resp.find_model(status_code)):
-                result[0] = result.dict()
-                skip_validation = True
-
-        # If we just have a Pydantic Model then find the status code
-        # from the validator configuration, if there is no code for
-        # the given model then validate it as normal
+            result[0] = result.dict()
+            skip_validation = True
         elif resp and isinstance(result, BaseModel):
-            status_code = resp.find_status_from_model(result.__class__)
-            if status_code:
-                result = result.dict(), status_code
-                skip_validation = True
+            result = result.dict()
+            skip_validation = True
 
         response = make_response(result)
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -191,7 +191,11 @@ class FlaskPlugin(BasePlugin):
         result = func(*args, **kwargs)
 
         if resp and isinstance(result, tuple) and isinstance(result[0], BaseModel):
-            result[0] = result.dict()
+            if len(result) > 1:
+                result = result[0].dict(), *result[1:]
+            else:
+                result = (result[0].dict(),)
+
             skip_validation = True
         elif resp and isinstance(result, BaseModel):
             result = result.dict()

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from functools import partial
 from json import JSONDecodeError
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from .base import BasePlugin, Context
 
@@ -60,6 +60,7 @@ class StarlettePlugin(BasePlugin):
         before,
         after,
         validation_error_status,
+        skip_validation,
         *args,
         **kwargs,
     ):
@@ -101,7 +102,11 @@ class StarlettePlugin(BasePlugin):
         else:
             response = func(*args, **kwargs)
 
-        if resp:
+        if isinstance(response.body, BaseModel):
+            response.body = response.body.dict()
+            skip_validation = True
+
+        if resp and not skip_validation:
             model = resp.find_model(response.status_code)
             if model:
                 try:

--- a/spectree/response.py
+++ b/spectree/response.py
@@ -102,6 +102,15 @@ class Response:
         """
         return self.code_models.get(f"HTTP_{code}")
 
+    def find_status_from_model(self, model: ModelType) -> Optional[str]:
+        """
+        Find the mapped status type for a given model
+        Returns None if not found
+        """
+        for _status, _model in self.code_models.items():
+            if _model == model:
+                return int(_status[-3:])
+
     def get_code_description(self, code: str) -> str:
         """Get the description of the given status code.
 

--- a/spectree/response.py
+++ b/spectree/response.py
@@ -102,15 +102,6 @@ class Response:
         """
         return self.code_models.get(f"HTTP_{code}")
 
-    def find_status_from_model(self, model: ModelType) -> Optional[str]:
-        """
-        Find the mapped status type for a given model
-        Returns None if not found
-        """
-        for _status, _model in self.code_models.items():
-            if _model == model:
-                return int(_status[-3:])
-
     def get_code_description(self, code: str) -> str:
         """Get the description of the given status code.
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -114,6 +114,7 @@ class SpecTree:
         after: Callable = None,
         validation_error_status: int = 0,
         path_parameter_descriptions: Mapping[str, str] = None,
+        skip_validation: bool = False,
     ) -> Callable:
         """
         - validate query, json, headers in request
@@ -159,6 +160,7 @@ class SpecTree:
                     before or self.before,
                     after or self.after,
                     validation_error_status,
+                    skip_validation,
                     *args,
                     **kwargs,
                 )
@@ -176,6 +178,7 @@ class SpecTree:
                     before or self.before,
                     after or self.after,
                     validation_error_status,
+                    skip_validation,
                     *args,
                     **kwargs,
                 )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -48,6 +48,8 @@ def test_plugin_spec(api):
         "/api/user/{name}",
         "/api/user/{name}/address/{address_id}",
         "/api/user_annotated/{name}",
+        "/api/user_model/{name}",
+        "/api/user_skip/{name}",
         "/ping",
     ]
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -87,6 +87,58 @@ class UserScoreAnnotated:
         assert req.cookies["pub"] == "abcdefg"
         resp.media = {"name": req.context.json.name, "score": score}
 
+class UserScoreSkip:
+    name = "sorted random score"
+
+    def extra_method(self):
+        pass
+
+    @api.validate(resp=Response(HTTP_200=StrDict))
+    def on_get(self, req, resp, name):
+        self.extra_method()
+        resp.media = {"name": name}
+
+    @api.validate(
+        query=Query,
+        json=JSON,
+        cookies=Cookies,
+        resp=Response(HTTP_200=Resp, HTTP_401=None),
+        tags=[api_tag, "test"],
+        skip_validation=True,
+    )
+    def on_post(self, req, resp, name):
+        score = [randint(0, req.context.json.limit) for _ in range(5)]
+        score.sort(reverse=req.context.query.order)
+        assert req.context.cookies.pub == "abcdefg"
+        assert req.cookies["pub"] == "abcdefg"
+        resp.media = {"name": req.context.json.name, "x_score": score}
+
+
+class UserScoreModel:
+    name = "sorted random score"
+
+    def extra_method(self):
+        pass
+
+    @api.validate(resp=Response(HTTP_200=StrDict))
+    def on_get(self, req, resp, name):
+        self.extra_method()
+        resp.media = {"name": name}
+
+    @api.validate(
+        query=Query,
+        json=JSON,
+        cookies=Cookies,
+        resp=Response(HTTP_200=Resp, HTTP_401=None),
+        tags=[api_tag, "test"],
+    )
+    def on_post(self, req, resp, name):
+        score = [randint(0, req.context.json.limit) for _ in range(5)]
+        score.sort(reverse=req.context.query.order)
+        assert req.context.cookies.pub == "abcdefg"
+        assert req.cookies["pub"] == "abcdefg"
+        resp.media = Resp(name=req.context.json.name, score=score)
+
 
 class UserAddress:
     name = "user's address"
@@ -107,6 +159,8 @@ app.add_route("/ping", Ping())
 app.add_route("/api/user/{name}", UserScore())
 app.add_route("/api/user_annotated/{name}", UserScoreAnnotated())
 app.add_route("/api/user/{name}/address/{address_id}", UserAddress())
+app.add_route("/api/user_skip/{name}", UserScoreSkip())
+app.add_route("/api/user_model/{name}", UserScoreModel())
 api.register(app)
 
 
@@ -160,6 +214,27 @@ def test_falcon_validate(client):
     assert resp.headers.get("X-Name") == "sorted random score"
 
 
+def test_falcon_skip_validation(client):
+    resp = client.simulate_request(
+        "POST",
+        "/api/user_skip/falcon?order=1",
+        json=dict(name="falcon", limit=10),
+        headers={"Cookie": "pub=abcdefg"},
+    )
+    assert resp.json["name"] == "falcon"
+    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
+    assert resp.headers.get("X-Name") == "sorted random score"
+
+def test_falcon_return_model(client):
+    resp = client.simulate_request(
+        "POST",
+        "/api/user_model/falcon?order=1",
+        json=dict(name="falcon", limit=10),
+        headers={"Cookie": "pub=abcdefg"},
+    )
+    assert resp.json["name"] == "falcon"
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
+    assert resp.headers.get("X-Name") == "sorted random score"
 @pytest.fixture
 def test_client_and_api(request):
     api_args = ["falcon"]
@@ -256,3 +331,6 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     for doc_page in expected_doc_pages:
         resp = client.simulate_get(f"/apidoc/{doc_page}")
         assert resp.status_code == 200
+
+
+"""Test skipping validation and return models directly"""

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -57,7 +57,7 @@ class UserScore:
         resp=Response(HTTP_200=Resp, HTTP_401=None),
         tags=[api_tag, "test"],
     )
-    def on_post(self, req, resp, name):
+    def on_post(self, req, resp, name, query: Query, json: JSON, cookies: Cookies):
         score = [randint(0, req.context.json.limit) for _ in range(5)]
         score.sort(reverse=req.context.query.order)
         assert req.context.cookies.pub == "abcdefg"
@@ -107,7 +107,7 @@ class UserScoreSkip:
         tags=[api_tag, "test"],
         skip_validation=True,
     )
-    def on_post(self, req, resp, name):
+    def on_post(self, req, resp, name, query: Query, json: JSON, cookies: Cookies):
         score = [randint(0, req.context.json.limit) for _ in range(5)]
         score.sort(reverse=req.context.query.order)
         assert req.context.cookies.pub == "abcdefg"
@@ -133,7 +133,7 @@ class UserScoreModel:
         resp=Response(HTTP_200=Resp, HTTP_401=None),
         tags=[api_tag, "test"],
     )
-    def on_post(self, req, resp, name):
+    def on_post(self, req, resp, name, query: Query, json: JSON, cookies: Cookies):
         score = [randint(0, req.context.json.limit) for _ in range(5)]
         score.sort(reverse=req.context.query.order)
         assert req.context.cookies.pub == "abcdefg"

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -87,6 +87,7 @@ class UserScoreAnnotated:
         assert req.cookies["pub"] == "abcdefg"
         resp.media = {"name": req.context.json.name, "score": score}
 
+
 class UserScoreSkip:
     name = "sorted random score"
 
@@ -225,6 +226,7 @@ def test_falcon_skip_validation(client):
     assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
     assert resp.headers.get("X-Name") == "sorted random score"
 
+
 def test_falcon_return_model(client):
     resp = client.simulate_request(
         "POST",
@@ -235,6 +237,8 @@ def test_falcon_return_model(client):
     assert resp.json["name"] == "falcon"
     assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
     assert resp.headers.get("X-Name") == "sorted random score"
+
+
 @pytest.fixture
 def test_client_and_api(request):
     api_args = ["falcon"]

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -171,16 +171,22 @@ def client():
 
 
 def test_falcon_validate(client):
-    resp = client.simulate_request("GET", "/ping", headers={"Content-Type": "text/plain"})
+    resp = client.simulate_request(
+        "GET", "/ping", headers={"Content-Type": "text/plain"}
+    )
     assert resp.status_code == 422
     assert resp.headers.get("X-Error") == "Validation Error", resp.headers
 
-    resp = client.simulate_request("GET", "/ping", headers={"lang": "en-US", "Content-Type": "text/plain"})
+    resp = client.simulate_request(
+        "GET", "/ping", headers={"lang": "en-US", "Content-Type": "text/plain"}
+    )
     assert resp.json == {"msg": "pong"}
     assert resp.headers.get("X-Error") is None
     assert resp.headers.get("X-Name") == "health check"
 
-    resp = client.simulate_request("GET", "/api/user/falcon", headers={"Content-Type": "text/plain"})
+    resp = client.simulate_request(
+        "GET", "/api/user/falcon", headers={"Content-Type": "text/plain"}
+    )
     assert resp.json == {"name": "falcon"}
 
     resp = client.simulate_request("POST", "/api/user/falcon")
@@ -296,10 +302,14 @@ def test_client_and_api(request):
     ],
     indirect=["test_client_and_api"],
 )
-def test_validation_error_response_status_code(test_client_and_api, expected_status_code):
+def test_validation_error_response_status_code(
+    test_client_and_api, expected_status_code
+):
     app_client, _ = test_client_and_api
 
-    resp = app_client.simulate_request("GET", "/ping", headers={"Content-Type": "text/plain"})
+    resp = app_client.simulate_request(
+        "GET", "/ping", headers={"Content-Type": "text/plain"}
+    )
 
     assert resp.status_code == expected_status_code
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -171,22 +171,16 @@ def client():
 
 
 def test_falcon_validate(client):
-    resp = client.simulate_request(
-        "GET", "/ping", headers={"Content-Type": "text/plain"}
-    )
+    resp = client.simulate_request("GET", "/ping", headers={"Content-Type": "text/plain"})
     assert resp.status_code == 422
     assert resp.headers.get("X-Error") == "Validation Error", resp.headers
 
-    resp = client.simulate_request(
-        "GET", "/ping", headers={"lang": "en-US", "Content-Type": "text/plain"}
-    )
+    resp = client.simulate_request("GET", "/ping", headers={"lang": "en-US", "Content-Type": "text/plain"})
     assert resp.json == {"msg": "pong"}
     assert resp.headers.get("X-Error") is None
     assert resp.headers.get("X-Name") == "health check"
 
-    resp = client.simulate_request(
-        "GET", "/api/user/falcon", headers={"Content-Type": "text/plain"}
-    )
+    resp = client.simulate_request("GET", "/api/user/falcon", headers={"Content-Type": "text/plain"})
     assert resp.json == {"name": "falcon"}
 
     resp = client.simulate_request("POST", "/api/user/falcon")
@@ -302,14 +296,10 @@ def test_client_and_api(request):
     ],
     indirect=["test_client_and_api"],
 )
-def test_validation_error_response_status_code(
-    test_client_and_api, expected_status_code
-):
+def test_validation_error_response_status_code(test_client_and_api, expected_status_code):
     app_client, _ = test_client_and_api
 
-    resp = app_client.simulate_request(
-        "GET", "/ping", headers={"Content-Type": "text/plain"}
-    )
+    resp = app_client.simulate_request("GET", "/ping", headers={"Content-Type": "text/plain"})
 
     assert resp.status_code == expected_status_code
 
@@ -335,6 +325,3 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     for doc_page in expected_doc_pages:
         resp = client.simulate_get(f"/apidoc/{doc_page}")
         assert resp.status_code == 200
-
-
-"""Test skipping validation and return models directly"""

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -86,6 +86,40 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=json.name, score=score)
 
+@app.route("/api/user_skip/<name>", methods=["POST"])
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+    after=api_after_handler,
+    skip_validation=True,
+)
+def user_score_skip_validation(name):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return jsonify(name=request.context.json.name, x_score=score)
+
+
+@app.route("/api/user_model/<name>", methods=["POST"])
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+    after=api_after_handler,
+)
+def user_score_model(name):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return Resp(name=request.context.json.name, score=score)
+
 
 @app.route("/api/user/<name>/address/<address_id>", methods=["GET"])
 @api.validate(
@@ -155,6 +189,36 @@ def test_flask_validate(client):
         )
         assert resp.status_code == 200, resp.json
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+
+def test_flask_skip_validation(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"/api/user_skip/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
+
+
+def test_flask_return_model(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"/api/user_model/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
 
 
 @pytest.fixture

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -196,7 +196,7 @@ def test_flask_skip_validation(client):
     client.set_cookie("flask", "pub", "abcdefg")
 
     resp = client.post(
-        f"/api/user_skip/flask?order=1",
+        "/api/user_skip/flask?order=1",
         data=json.dumps(dict(name="flask", limit=10)),
         content_type="application/json",
     )
@@ -211,7 +211,7 @@ def test_flask_return_model(client):
     client.set_cookie("flask", "pub", "abcdefg")
 
     resp = client.post(
-        f"/api/user_model/flask?order=1",
+        "/api/user_model/flask?order=1",
         data=json.dumps(dict(name="flask", limit=10)),
         content_type="application/json",
     )

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -119,7 +119,7 @@ def user_score_model(name):
     score.sort(reverse=True if request.context.query.order == Order.desc else False)
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
-    return Resp(name=request.context.json.name, score=score)
+    return Resp(name=request.context.json.name, score=score), 200
 
 
 @app.route("/api/user/<name>/address/<address_id>", methods=["GET"])

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -86,6 +86,7 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=json.name, score=score)
 
+
 @app.route("/api/user_skip/<name>", methods=["POST"])
 @api.validate(
     query=Query,

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -75,6 +75,39 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=json.name, score=score)
 
+@app.route("/api/user_skip/<name>", methods=["POST"])
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+    after=api_after_handler,
+    skip_validation=True,
+)
+def user_score_skip_validation(name):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return jsonify(name=request.context.json.name, x_score=score)
+
+
+@app.route("/api/user_model/<name>", methods=["POST"])
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+    after=api_after_handler,
+)
+def user_score_model(name):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return Resp(name=request.context.json.name, score=score)
 
 @app.route("/api/user/<name>/address/<address_id>", methods=["GET"])
 @api.validate(
@@ -139,6 +172,42 @@ def test_flask_validate(client, prefix):
         content_type="application/json",
     )
     assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+
+@pytest.mark.parametrize(
+    ("client", "prefix"), [(None, ""), ("/prefix", "/prefix")], indirect=["client"]
+)
+def test_flask_skip_validation(client, prefix):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"{prefix}/api/user_skip/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
+
+
+@pytest.mark.parametrize(
+    ("client", "prefix"), [(None, ""), ("/prefix", "/prefix")], indirect=["client"]
+)
+def test_flask_return_model(client, prefix):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"{prefix}/api/user_model/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
 
 
 @pytest.fixture

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -75,6 +75,7 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=json.name, score=score)
 
+
 @app.route("/api/user_skip/<name>", methods=["POST"])
 @api.validate(
     query=Query,
@@ -108,6 +109,7 @@ def user_score_model(name):
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return Resp(name=request.context.json.name, score=score)
+
 
 @app.route("/api/user/<name>/address/<address_id>", methods=["GET"])
 @api.validate(

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -69,6 +69,7 @@ class UserAnnotated(MethodView):
         assert request.cookies["pub"] == "abcdefg"
         return jsonify(name=json.name, score=score)
 
+
 class UserSkip(MethodView):
     @api.validate(
         query=Query,
@@ -86,6 +87,7 @@ class UserSkip(MethodView):
         assert request.cookies["pub"] == "abcdefg"
         return jsonify(name=request.context.json.name, x_score=score)
 
+
 class UserModel(MethodView):
     @api.validate(
         query=Query,
@@ -101,6 +103,7 @@ class UserModel(MethodView):
         assert request.context.cookies.pub == "abcdefg"
         assert request.cookies["pub"] == "abcdefg"
         return Resp(name=request.context.json.name, score=score)
+
 
 class UserAddress(MethodView):
     @api.validate(
@@ -223,6 +226,7 @@ def test_flask_return_model(client):
     assert resp.headers.get("X-API") == "OK"
     assert resp.json["name"] == "flask"
     assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
+
 
 @pytest.fixture
 def test_client_and_api(request):

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -202,7 +202,7 @@ def test_flask_skip_validation(client):
     client.set_cookie("flask", "pub", "abcdefg")
 
     resp = client.post(
-        f"/api/user_skip/flask?order=1",
+        "/api/user_skip/flask?order=1",
         data=json.dumps(dict(name="flask", limit=10)),
         content_type="application/json",
     )
@@ -217,7 +217,7 @@ def test_flask_return_model(client):
     client.set_cookie("flask", "pub", "abcdefg")
 
     resp = client.post(
-        f"/api/user_model/flask?order=1",
+        "/api/user_model/flask?order=1",
         data=json.dumps(dict(name="flask", limit=10)),
         content_type="application/json",
     )

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -69,6 +69,38 @@ class UserAnnotated(MethodView):
         assert request.cookies["pub"] == "abcdefg"
         return jsonify(name=json.name, score=score)
 
+class UserSkip(MethodView):
+    @api.validate(
+        query=Query,
+        json=JSON,
+        cookies=Cookies,
+        resp=Response(HTTP_200=Resp, HTTP_401=None),
+        tags=[api_tag, "test"],
+        after=api_after_handler,
+        skip_validation=True,
+    )
+    def post(self, name, query: Query, json: JSON, cookies: Cookies):
+        score = [randint(0, request.context.json.limit) for _ in range(5)]
+        score.sort(reverse=True if request.context.query.order == Order.desc else False)
+        assert request.context.cookies.pub == "abcdefg"
+        assert request.cookies["pub"] == "abcdefg"
+        return jsonify(name=request.context.json.name, x_score=score)
+
+class UserModel(MethodView):
+    @api.validate(
+        query=Query,
+        json=JSON,
+        cookies=Cookies,
+        resp=Response(HTTP_200=Resp, HTTP_401=None),
+        tags=[api_tag, "test"],
+        after=api_after_handler,
+    )
+    def post(self, name, query: Query, json: JSON, cookies: Cookies):
+        score = [randint(0, request.context.json.limit) for _ in range(5)]
+        score.sort(reverse=True if request.context.query.order == Order.desc else False)
+        assert request.context.cookies.pub == "abcdefg"
+        assert request.cookies["pub"] == "abcdefg"
+        return Resp(name=request.context.json.name, score=score)
 
 class UserAddress(MethodView):
     @api.validate(
@@ -87,6 +119,16 @@ app.add_url_rule("/api/user/<name>", view_func=User.as_view("user"), methods=["P
 app.add_url_rule(
     "/api/user_annotated/<name>",
     view_func=UserAnnotated.as_view("user_annotated"),
+    methods=["POST"],
+)
+app.add_url_rule(
+    "/api/user_skip/<name>",
+    view_func=UserSkip.as_view("user_skip"),
+    methods=["POST"],
+)
+app.add_url_rule(
+    "/api/user_model/<name>",
+    view_func=UserModel.as_view("user_model"),
     methods=["POST"],
 )
 app.add_url_rule(
@@ -152,6 +194,35 @@ def test_flask_validate(client):
         )
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
 
+
+def test_flask_skip_validation(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"/api/user_skip/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
+
+
+def test_flask_return_model(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        f"/api/user_model/flask?order=1",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
 
 @pytest.fixture
 def test_client_and_api(request):

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -9,13 +9,9 @@ from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
 
 from spectree import Response, SpecTree
+from spectree.plugins.starlette_plugin import PydanticResponse
 
 from .common import JSON, Cookies, Headers, Order, Query, Resp, StrDict, api_tag
-
-
-class PydanticResponse(JSONResponse):
-    def render(self, content) -> bytes:
-        return super().render(content.dict())
 
 
 def before_handler(req, resp, err, instance):

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -3,7 +3,7 @@ from random import randint
 import pytest
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.testclient import TestClient
@@ -73,6 +73,34 @@ async def user_score_annotated(request, query: Query, json: JSON, cookies: Cooki
     assert request.cookies["pub"] == "abcdefg"
     return JSONResponse({"name": json.name, "score": score})
 
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+    skip_validation=True,
+)
+async def user_score_skip(request):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return JSONResponse({"name": request.context.json.name, "x_score": score})
+
+@api.validate(
+    query=Query,
+    json=JSON,
+    cookies=Cookies,
+    resp=Response(HTTP_200=Resp, HTTP_401=None),
+    tags=[api_tag, "test"],
+)
+async def user_score_model(request):
+    score = [randint(0, request.context.json.limit) for _ in range(5)]
+    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    assert request.context.cookies.pub == "abcdefg"
+    assert request.cookies["pub"] == "abcdefg"
+    return Response(Resp(name=request.context.json.name, score=score))
 
 app = Starlette(
     routes=[
@@ -90,6 +118,18 @@ app = Starlette(
                     "/user_annotated",
                     routes=[
                         Route("/{name}", user_score_annotated, methods=["POST"]),
+                    ],
+                ),
+                Mount(
+                    "/user_skip",
+                    routes=[
+                        Route("/{name}", user_score_skip, methods=["POST"]),
+                    ],
+                ),
+                Mount(
+                    "/user_model",
+                    routes=[
+                        Route("/{name}", user_score_model, methods=["POST"]),
                     ],
                 ),
             ],
@@ -157,6 +197,30 @@ def test_starlette_validate(client):
         assert resp_body["name"] == "starlette"
         assert resp_body["score"] == sorted(resp_body["score"], reverse=False)
         assert resp.headers.get("X-Validation") == "Pass"
+
+
+def test_starlette_skip_validation(client):
+    resp = client.post(
+        f"/api/user_skip/starlette?order=1",
+        json=dict(name="starlette", limit=10),
+        cookies=dict(pub="abcdefg"),
+    )
+    resp_body = resp.json()
+    assert resp_body["name"] == "starlette"
+    assert resp_body["x_score"] == sorted(resp_body["x_score"], reverse=True)
+    assert resp.headers.get("X-Validation") == "Pass"
+
+
+def test_starlette_return_model(client):
+    resp = client.post(
+        f"/api/user_model/starlette?order=1",
+        json=dict(name="starlette", limit=10),
+        cookies=dict(pub="abcdefg"),
+    )
+    resp_body = resp.json()
+    assert resp_body["name"] == "starlette"
+    assert resp_body["score"] == sorted(resp_body["score"], reverse=True)
+    assert resp.headers.get("X-Validation") == "Pass"
 
 
 @pytest.fixture

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -73,6 +73,7 @@ async def user_score_annotated(request, query: Query, json: JSON, cookies: Cooki
     assert request.cookies["pub"] == "abcdefg"
     return JSONResponse({"name": json.name, "score": score})
 
+
 @api.validate(
     query=Query,
     json=JSON,
@@ -88,6 +89,7 @@ async def user_score_skip(request):
     assert request.cookies["pub"] == "abcdefg"
     return JSONResponse({"name": request.context.json.name, "x_score": score})
 
+
 @api.validate(
     query=Query,
     json=JSON,
@@ -101,6 +103,7 @@ async def user_score_model(request):
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return Response(Resp(name=request.context.json.name, score=score))
+
 
 app = Starlette(
     routes=[


### PR DESCRIPTION
For #160 

This PR adds two new pieces of functionality

- `api.validate` now accepts a `skip_validation` argument that will skip the validation entirely and allow returning invalid responses
- If the view returns a `BaseModel` instance then spectree will automatically call `.dict()` on it and assume it's already validated and skip validation 

I've also added some `pip install`s to the Makefile.

The only issue with this is that Starlette only supports returning hashable types  - which pydantic models are not.
The tests currently fail on this.

Do you have a preference of how to handle this?

I was thinking either 
- Remove support for returning models directly as users can write a wrapper validator to call `.dict()` and set `skip_validation=True`
- Just don't support returning models for Starlette - but this means different backends have different features, is that already the case or does spectree have feature parity across all backends?