### PR TITLE
fix: handle case when no view response is defined

### DIFF
--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -226,11 +226,11 @@ class FalconPlugin(BasePlugin):
         func(*args, **kwargs)
 
         if resp and resp.has_model():
-            if isinstance(_resp.media, resp.find_model(_resp.status[:3])):
+            model = resp.find_model(_resp.status[:3])
+            if model and isinstance(_resp.media, model):
                 _resp.media = _resp.media.dict()
                 skip_validation = True
 
-            model = resp.find_model(_resp.status[:3])
             if model and not skip_validation:
                 try:
                     model.parse_obj(_resp.media)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -200,7 +200,11 @@ class FlaskPlugin(BasePlugin):
         else:
             model = result
 
-        if isinstance(model, resp.find_model(status)):
+        if (
+            resp
+            and resp.find_model(status)
+            and isinstance(model, resp.find_model(status))
+        ):
             skip_validation = True
             result = (model.dict(), status, *rest)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -54,6 +54,7 @@ def test_plugin_spec(api):
     ]
 
     assert get_paths(api.spec) == [
+        "/api/no_response",
         "/api/user/{name}",
         "/api/user/{name}/address/{address_id}",
         "/api/user_annotated/{name}",

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -16,9 +16,7 @@ def before_handler(req, resp, err, instance):
 
 
 def after_handler(req, resp, err, instance):
-    print(instance.name)
     resp.set_header("X-Name", instance.name)
-    print(resp.get_header("X-Name"))
 
 
 api = SpecTree(

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -134,6 +134,14 @@ def user_address(name, address_id):
     return None
 
 
+@app.route("/api/no_response", methods=["GET", "POST"])
+@api.validate(
+    json=Query,
+)
+def no_response():
+    return {}
+
+
 # INFO: ensures that spec is calculated and cached _after_ registering
 # view functions for validations. This enables tests to access `api.spec`
 # without app_context.

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -123,6 +123,14 @@ def user_address(name, address_id):
     return None
 
 
+@app.route("/api/no_response", methods=["GET", "POST"])
+@api.validate(
+    json=Query,
+)
+def no_response():
+    return {}
+
+
 api.register(app)
 
 flask_app = Flask(__name__)

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -117,6 +117,20 @@ class UserAddress(MethodView):
         return None
 
 
+class NoResponseView(MethodView):
+    @api.validate(
+        resp=Response(HTTP_200=None),  # response is None
+    )
+    def get(self):
+        return {}
+
+    @api.validate(
+        json=Query,  # resp is missing completely
+    )
+    def post(self, json: Query):
+        return {}
+
+
 app.add_url_rule("/ping", view_func=Ping.as_view("ping"))
 app.add_url_rule("/api/user/<name>", view_func=User.as_view("user"), methods=["POST"])
 app.add_url_rule(
@@ -138,6 +152,10 @@ app.add_url_rule(
     "/api/user/<name>/address/<address_id>",
     view_func=UserAddress.as_view("user_address"),
     methods=["GET"],
+)
+app.add_url_rule(
+    "/api/no_response",
+    view_func=NoResponseView.as_view("no_response_view"),
 )
 
 # INFO: ensures that spec is calculated and cached _after_ registering
@@ -196,6 +214,12 @@ def test_flask_validate(client):
             content_type="application/x-www-form-urlencoded",
         )
         assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+    resp = client.get("/api/no_response")
+    assert resp.status_code == 200
+
+    resp = client.post("/api/no_response", data={"order": 1})
+    assert resp.status_code == 200
 
 
 def test_flask_skip_validation(client):

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -106,6 +106,14 @@ async def user_score_model(request):
     return PydanticResponse(Resp(name=request.context.json.name, score=score))
 
 
+@api.validate(
+    json=JSON,
+    resp=Response(HTTP_200=None),
+)
+async def no_response(request):
+    return JSONResponse({})
+
+
 app = Starlette(
     routes=[
         Route("/ping", Ping),
@@ -136,6 +144,7 @@ app = Starlette(
                         Route("/{name}", user_score_model, methods=["POST"]),
                     ],
                 ),
+                Route("/no_response", no_response, methods=["POST", "GET"]),
             ],
         ),
         Mount("/static", app=StaticFiles(directory="docs"), name="static"),


### PR DESCRIPTION
hi,
there seems to be a regression introduced in #212

it can happen in two situations, each ending with different error:


-  the value of specific status code for `resp` in `@api.validate` is `None`:
```
>       if isinstance(model, resp.find_model(status)):
E       TypeError: isinstance() arg 2 must be a type or tuple of types
```

- `resp` in `@api.validate()` is not declared at all:
```
>       isinstance(model, resp.find_model(status)):
E       AttributeError: 'NoneType' object has no attribute 'find_model'
```

the error was raised in plugins for `flask` and `falcon`, `starlette` was working fine.


this PR adds fix for the two plugins + tests for all three of them.