### PR TITLE
Flask: add trailing slash to apidoc routes

### DIFF
--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -257,7 +257,7 @@ class FlaskPlugin(BasePlugin):
 
             for ui in self.config.page_templates:
                 app.add_url_rule(
-                    rule=f"/{self.config.path}/{ui}",
+                    rule=f"/{self.config.path}/{ui}/",
                     endpoint=f"openapi_{self.config.path}_{ui.replace('.', '_')}",
                     view_func=lambda ui=ui: gen_doc_page(ui),
                 )
@@ -266,7 +266,7 @@ class FlaskPlugin(BasePlugin):
         else:
             for ui in self.config.page_templates:
                 app.add_url_rule(
-                    rule=f"/{self.config.path}/{ui}",
+                    rule=f"/{self.config.path}/{ui}/",
                     endpoint=f"openapi_{self.config.path}_{ui}",
                     view_func=lambda ui=ui: self.config.page_templates[ui].format(
                         spec_url=self.config.spec_url,

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -325,8 +325,10 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        resp = client.get(f"/apidoc/{doc_page}")
+        location = f"/apidoc/{doc_page}"
+        resp = client.get(location, follow_redirects=True)
         assert resp.status_code == 200
+        assert resp.location == f"{location}/"
 
 
 """

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -325,10 +325,11 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        location = f"/apidoc/{doc_page}"
-        resp = client.get(location, follow_redirects=True)
+        resp = client.get(f"/apidoc/{doc_page}/")
         assert resp.status_code == 200
-        assert resp.location == f"{location}/"
+
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 308
 
 
 """

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -320,8 +320,10 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        resp = client.get(f"/apidoc/{doc_page}")
+        location = f"/apidoc/{doc_page}"
+        resp = client.get(location, follow_redirects=True)
         assert resp.status_code == 200
+        assert resp.location == f"{location}/"
 
 
 @pytest.mark.parametrize(
@@ -338,10 +340,10 @@ def test_flask_doc_prefix(test_client_and_api, prefix):
     resp = client.get(prefix + "/apidoc/openapi.json")
     assert resp.json == api.spec
 
-    resp = client.get(prefix + "/apidoc/redoc")
+    resp = client.get(prefix + "/apidoc/redoc/")
     assert resp.status_code == 200
 
-    resp = client.get(prefix + "/apidoc/swagger")
+    resp = client.get(prefix + "/apidoc/swagger/")
     assert resp.status_code == 200
 
     assert get_paths(api.spec) == [

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -320,10 +320,11 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        location = f"/apidoc/{doc_page}"
-        resp = client.get(location, follow_redirects=True)
+        resp = client.get(f"/apidoc/{doc_page}/")
         assert resp.status_code == 200
-        assert resp.location == f"{location}/"
+
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 308
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -349,5 +349,7 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        resp = client.get(f"/apidoc/{doc_page}")
+        location = f"/apidoc/{doc_page}"
+        resp = client.get(location, follow_redirects=True)
         assert resp.status_code == 200
+        assert resp.location == f"{location}/"

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -349,7 +349,8 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     assert resp.json == api.spec
 
     for doc_page in expected_doc_pages:
-        location = f"/apidoc/{doc_page}"
-        resp = client.get(location, follow_redirects=True)
+        resp = client.get(f"/apidoc/{doc_page}/")
         assert resp.status_code == 200
-        assert resp.location == f"{location}/"
+
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 308


### PR DESCRIPTION
## Current behaviour

`add_url_rule()` in Flask plugin are defined without trailing slash, so only the paths without it work, ie:
 ```
$ curl -i http://localhost:5000/apidoc/swagger/ |grep HTTP
HTTP/1.0 404 NOT FOUND

$ curl -i http://localhost:5000/apidoc/swagger |grep HTTP
HTTP/1.0 200 OK
```

## Expected behaviour

Default behaviour in Flask regarding trailing slashes is [documented as follows](https://werkzeug.palletsprojects.com/en/2.1.x/routing/#rule-format):

> Rules that end with a slash are “branches”, others are “leaves”. If `strict_slashes` is enabled (the default), visiting a branch URL without a trailing slash will redirect to the URL with a slash 

adding the trailing slash into the routes definition makes both options work:
 ```
$ curl -i http://localhost:5000/apidoc/swagger/ |grep HTTP
HTTP/1.0 200 OK

$ curl -i http://localhost:5000/apidoc/swagger |grep HTTP
HTTP/1.0 308 PERMANENT REDIRECT
```




