### PR TITLE
add support for form data request 

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field
+
+from spectree import BaseFile
+
+
+class File(BaseModel):
+    uid: str
+    file: BaseFile
+
+
+class FileResp(BaseModel):
+    filename: str
+    type: str
+
+
+class Query(BaseModel):
+    text: str = Field(
+        ...,
+        max_length=100,
+    )

--- a/examples/falcon_asgi_demo.py
+++ b/examples/falcon_asgi_demo.py
@@ -2,9 +2,10 @@ import logging
 from random import random
 
 import falcon.asgi
+import uvicorn
 from pydantic import BaseModel, Field
 
-from spectree import Response, SpecTree, Tag, models
+from spectree import BaseFile, Response, SpecTree, Tag
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -53,12 +54,13 @@ class Data(BaseModel):
 
 
 class File(BaseModel):
-    uid: str
-    file: models.BaseFile
+    uid: str = None
+    file: BaseFile
 
 
 class FileResp(BaseModel):
     filename: str
+    type: str
 
 
 class Ping:
@@ -121,11 +123,14 @@ class FileUpload:
         demo for 'form'
         """
         file = req.context.form.file
-        resp.media = {"filename": file.filename}
+        resp.media = {"filename": file.filename, "type": file.type}
 
 
-app = falcon.asgi.App()
-app.add_route("/ping", Ping())
-app.add_route("/api/{source}/{target}", Classification())
-app.add_route("/api/upload-file", FileUpload())
-api.register(app)
+if __name__ == "__main__":
+    app = falcon.asgi.App()
+    app.add_route("/ping", Ping())
+    app.add_route("/api/{source}/{target}", Classification())
+    app.add_route("/api/upload-file", FileUpload())
+    api.register(app)
+
+    uvicorn.run(app, log_level="info")

--- a/examples/falcon_asgi_demo.py
+++ b/examples/falcon_asgi_demo.py
@@ -5,11 +5,11 @@ import falcon.asgi
 import uvicorn
 from pydantic import BaseModel, Field
 
-from spectree import BaseFile, Response, SpecTree, Tag
+from examples.common import File, FileResp, Query
+from spectree import Response, SpecTree, Tag
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
-
 
 api = SpecTree(
     "falcon-asgi",
@@ -19,13 +19,6 @@ api = SpecTree(
 )
 
 demo = Tag(name="demo", description="😊", externalDocs={"url": "https://github.com"})
-
-
-class Query(BaseModel):
-    text: str = Field(
-        ...,
-        max_length=100,
-    )
 
 
 class Resp(BaseModel):
@@ -51,16 +44,6 @@ class Data(BaseModel):
     uid: str
     limit: int
     vip: bool
-
-
-class File(BaseModel):
-    uid: str = None
-    file: BaseFile
-
-
-class FileResp(BaseModel):
-    filename: str
-    type: str
 
 
 class Ping:
@@ -130,7 +113,7 @@ if __name__ == "__main__":
     app = falcon.asgi.App()
     app.add_route("/ping", Ping())
     app.add_route("/api/{source}/{target}", Classification())
-    app.add_route("/api/upload-file", FileUpload())
+    app.add_route("/api/file_upload", FileUpload())
     api.register(app)
 
     uvicorn.run(app, log_level="info")

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -5,7 +5,7 @@ from wsgiref import simple_server
 import falcon
 from pydantic import BaseModel, Field
 
-from spectree import Response, SpecTree, Tag, models
+from spectree import BaseFile, Response, SpecTree, Tag
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -57,12 +57,13 @@ class Data(BaseModel):
 
 
 class File(BaseModel):
-    uid: str
-    file: models.BaseFile
+    uid: str = None
+    file: BaseFile
 
 
 class FileResp(BaseModel):
     filename: str
+    type: str
 
 
 class Ping:
@@ -125,7 +126,7 @@ class FileUpload:
         demo for 'form'
         """
         file = req.context.form.file
-        resp.media = {"filename": file.filename}
+        resp.media = {"filename": file.filename, "type": file.type}
 
 
 class JSONFormatter(logging.Formatter):
@@ -171,7 +172,5 @@ if __name__ == "__main__":
     app.add_route("/api/upload-file", FileUpload())
     api.register(app)
 
-    httpd = simple_server.make_server("localhost", 8002, app)
-    logger.info("Swagger documentation: %s/swagger" % "http://localhost:8000/apidoc")
-    logger.info("Redoc documentation: %s/redoc" % "http://localhost:8000/apidoc")
+    httpd = simple_server.make_server("localhost", 8000, app)
     httpd.serve_forever()

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -5,11 +5,11 @@ from wsgiref import simple_server
 import falcon
 from pydantic import BaseModel, Field
 
-from spectree import BaseFile, Response, SpecTree, Tag
+from examples.common import File, FileResp, Query
+from spectree import Response, SpecTree, Tag
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
-
 
 api = SpecTree(
     "falcon",
@@ -22,13 +22,6 @@ api = SpecTree(
 )
 
 demo = Tag(name="demo", description="😊", externalDocs={"url": "https://github.com"})
-
-
-class Query(BaseModel):
-    text: str = Field(
-        ...,
-        max_length=100,
-    )
 
 
 class Resp(BaseModel):
@@ -54,16 +47,6 @@ class Data(BaseModel):
     uid: str
     limit: int
     vip: bool
-
-
-class File(BaseModel):
-    uid: str = None
-    file: BaseFile
-
-
-class FileResp(BaseModel):
-    filename: str
-    type: str
 
 
 class Ping:
@@ -129,37 +112,6 @@ class FileUpload:
         resp.media = {"filename": file.filename, "type": file.type}
 
 
-class JSONFormatter(logging.Formatter):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        lr = logging.LogRecord(None, None, "", 0, "", (), None, None)
-        self.default_keys = [key for key in lr.__dict__]
-
-    def extra_data(self, record):
-        return {
-            key: getattr(record, key)
-            for key in record.__dict__
-            if key not in self.default_keys
-        }
-
-    def format(self, record):
-        log_data = {
-            "severity": record.levelname,
-            "path_name": record.pathname,
-            "function_name": record.funcName,
-            "message": record.msg,
-            **self.extra_data(record),
-        }
-        return json.dumps(log_data)
-
-
-logger = logging.getLogger()
-handler = logging.StreamHandler()
-handler.setFormatter(JSONFormatter())
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
-
-
 if __name__ == "__main__":
     """
     cmd:
@@ -169,7 +121,7 @@ if __name__ == "__main__":
     app = falcon.App()
     app.add_route("/ping", Ping())
     app.add_route("/api/{source}/{target}", Classification())
-    app.add_route("/api/upload-file", FileUpload())
+    app.add_route("/api/file_upload", FileUpload())
     api.register(app)
 
     httpd = simple_server.make_server("localhost", 8000, app)

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -5,7 +5,7 @@ from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
 from pydantic import BaseModel, Field
 
-from spectree import Response, SpecTree, models
+from spectree import BaseFile, Response, SpecTree
 
 app = Flask(__name__)
 api = SpecTree("flask")
@@ -40,13 +40,13 @@ class Data(BaseModel):
 
 
 class File(BaseModel):
-    uid: str
-    file: models.BaseFile
+    uid: str = None
+    file: BaseFile
 
 
 class FileResp(BaseModel):
     filename: str
-    content_length: int
+    type: str
 
 
 class Language(str, Enum):
@@ -99,7 +99,6 @@ def with_code_header():
     return jsonify(language=request.context.headers.Lang), 203, {"X": 233}
 
 
-
 @app.route("/api/upload-file", methods=["POST"])
 @api.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
 def with_file():
@@ -108,8 +107,8 @@ def with_file():
 
     demo for 'form'
     """
-    file_data = request.context.form.file
-    return jsonify(filename=file_data.filename, content_length=file_data.content_length)
+    file = request.context.form.file
+    return jsonify(filename=file.filename, type=file.content_type)
 
 
 class UserAPI(MethodView):

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -5,14 +5,11 @@ from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
 from pydantic import BaseModel, Field
 
-from spectree import BaseFile, Response, SpecTree
+from examples.common import File, FileResp, Query
+from spectree import Response, SpecTree
 
 app = Flask(__name__)
 api = SpecTree("flask")
-
-
-class Query(BaseModel):
-    text: str = "default query strings"
 
 
 class Resp(BaseModel):
@@ -37,16 +34,6 @@ class Data(BaseModel):
                 "vip": True,
             }
         }
-
-
-class File(BaseModel):
-    uid: str = None
-    file: BaseFile
-
-
-class FileResp(BaseModel):
-    filename: str
-    type: str
 
 
 class Language(str, Enum):
@@ -99,7 +86,7 @@ def with_code_header():
     return jsonify(language=request.context.headers.Lang), 203, {"X": 233}
 
 
-@app.route("/api/upload-file", methods=["POST"])
+@app.route("/api/file_upload", methods=["POST"])
 @api.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
 def with_file():
     """
@@ -108,14 +95,13 @@ def with_file():
     demo for 'form'
     """
     file = request.context.form.file
-    return jsonify(filename=file.filename, type=file.content_type)
+    return {"filename": file.filename, "type": file.content_type}
 
 
 class UserAPI(MethodView):
     @api.validate(json=Data, resp=Response(HTTP_200=Resp), tags=["test"])
     def post(self):
         return jsonify(label=int(10 * random()), score=random())
-        # return Resp(label=int(10 * random()), score=random())
 
 
 if __name__ == "__main__":

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -5,7 +5,7 @@ from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
 from pydantic import BaseModel, Field
 
-from spectree import Response, SpecTree
+from spectree import Response, SpecTree, models
 
 app = Flask(__name__)
 api = SpecTree("flask")
@@ -37,6 +37,16 @@ class Data(BaseModel):
                 "vip": True,
             }
         }
+
+
+class File(BaseModel):
+    uid: str
+    file: models.BaseFile
+
+
+class FileResp(BaseModel):
+    filename: str
+    content_length: int
 
 
 class Language(str, Enum):
@@ -87,6 +97,19 @@ def with_code_header():
     query with ``http POST :8000/api/header Lang:zh-CN Cookie:key=hello``
     """
     return jsonify(language=request.context.headers.Lang), 203, {"X": 233}
+
+
+
+@app.route("/api/upload-file", methods=["POST"])
+@api.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
+def with_file():
+    """
+    post multipart/form-data demo
+
+    demo for 'form'
+    """
+    file_data = request.context.form.file
+    return jsonify(filename=file_data.filename, content_length=file_data.content_length)
 
 
 class UserAPI(MethodView):

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -5,7 +5,7 @@ from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
-from spectree import Response, SpecTree, models
+from spectree import BaseFile, Response, SpecTree
 
 # from spectree.plugins.starlette_plugin import PydanticResponse
 
@@ -36,12 +36,13 @@ class Data(BaseModel):
 
 
 class File(BaseModel):
-    uid: str
-    file: models.BaseFile
+    uid: str = None
+    file: BaseFile
 
 
 class FileResp(BaseModel):
     filename: str
+    type: str
 
 
 @api.validate(query=Query, json=Data, resp=Response(HTTP_200=Resp), tags=["api"])
@@ -64,8 +65,8 @@ async def file_upload(request):
 
     demo for 'form'
     """
-    file_data = request.context.form.file
-    return JSONResponse({"filename": file_data.filename})
+    file = request.context.form.file
+    return JSONResponse({"filename": file.filename, "type": file.type})
 
 
 class Ping(HTTPEndpoint):
@@ -87,10 +88,11 @@ if __name__ == "__main__":
         routes=[
             Route("/ping", Ping),
             Mount(
-                "/api", routes=[
+                "/api",
+                routes=[
                     Route("/predict/{luck:int}", predict, methods=["POST"]),
-                    Route("/file-upload", file_upload, methods=["POST"])
-                ]
+                    Route("/file-upload", file_upload, methods=["POST"]),
+                ],
             ),
         ]
     )

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -5,15 +5,10 @@ from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
-from spectree import BaseFile, Response, SpecTree
-
-# from spectree.plugins.starlette_plugin import PydanticResponse
+from examples.common import File, FileResp, Query
+from spectree import Response, SpecTree
 
 api = SpecTree("starlette")
-
-
-class Query(BaseModel):
-    text: str
 
 
 class Resp(BaseModel):
@@ -33,16 +28,6 @@ class Data(BaseModel):
     uid: str
     limit: int
     vip: bool
-
-
-class File(BaseModel):
-    uid: str = None
-    file: BaseFile
-
-
-class FileResp(BaseModel):
-    filename: str
-    type: str
 
 
 @api.validate(query=Query, json=Data, resp=Response(HTTP_200=Resp), tags=["api"])

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "black~=22.3",
             "isort~=5.10",
             "autoflake~=1.4",
-            "mypy>=0.942",
+            "mypy>=0.971",
         ],
     },
     zip_safe=False,

--- a/spectree/__init__.py
+++ b/spectree/__init__.py
@@ -1,10 +1,10 @@
 import logging
 
-from .models import SecurityScheme, Tag
+from .models import BaseFile, SecurityScheme, Tag
 from .response import Response
 from .spec import SpecTree
 
-__all__ = ["SpecTree", "Response", "Tag", "SecurityScheme"]
+__all__ = ["SpecTree", "Response", "Tag", "SecurityScheme", "BaseFile"]
 
 # setup library logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -168,3 +168,26 @@ class Server(BaseModel):
 
     class Config:
         validate_assignment = True
+
+
+class BaseFile:
+    """
+    An uploaded file included as part of the request data.
+    """
+    @classmethod
+    def __get_validators__(cls) -> 'Callable[..., Any]':
+        # one or more validators may be yielded which will be called in the
+        # order to validate the input, each validator will receive as an input
+        # the value returned from the previous validator
+        yield cls.validate
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        field_schema.update(
+            format="binary",
+            type="string"
+        )
+
+    @classmethod
+    def validate(cls, value: Any):
+        return value

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Sequence
 
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -174,8 +174,9 @@ class BaseFile:
     """
     An uploaded file included as part of the request data.
     """
+
     @classmethod
-    def __get_validators__(cls) -> 'Callable[..., Any]':
+    def __get_validators__(cls) -> "Callable[..., Any]":
         # one or more validators may be yielded which will be called in the
         # order to validate the input, each validator will receive as an input
         # the value returned from the previous validator
@@ -183,11 +184,9 @@ class BaseFile:
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
-        field_schema.update(
-            format="binary",
-            type="string"
-        )
+        field_schema.update(format="binary", type="string")
 
     @classmethod
     def validate(cls, value: Any):
+        # https://github.com/luolingchun/flask-openapi3/blob/master/flask_openapi3/models/file.py
         return value

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Any, Callable, Dict, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -176,7 +176,7 @@ class BaseFile:
     """
 
     @classmethod
-    def __get_validators__(cls) -> "Callable[..., Any]":
+    def __get_validators__(cls):
         # one or more validators may be yielded which will be called in the
         # order to validate the input, each validator will receive as an input
         # the value returned from the previous validator

--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -1,6 +1,14 @@
 import logging
-from collections import namedtuple
-from typing import TYPE_CHECKING, Any, Callable, Generic, Mapping, Optional, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Mapping,
+    NamedTuple,
+    Optional,
+    TypeVar,
+)
 
 from .._types import ModelType
 from ..config import Configuration
@@ -10,7 +18,13 @@ if TYPE_CHECKING:
     # to avoid cyclic import
     from ..spec import SpecTree
 
-Context = namedtuple("Context", ["query", "json", "form", "headers", "cookies"])
+
+class Context(NamedTuple):
+    query: list
+    json: list
+    form: list
+    headers: dict
+    cookies: dict
 
 
 BackendRoute = TypeVar("BackendRoute")
@@ -25,6 +39,7 @@ class BasePlugin(Generic[BackendRoute]):
 
     # ASYNC: is it an async framework or not
     ASYNC = False
+    FORM_MIMETYPE = ("application/x-www-form-urlencoded", "multipart/form-data")
 
     def __init__(self, spectree: "SpecTree"):
         self.spectree = spectree
@@ -44,6 +59,7 @@ class BasePlugin(Generic[BackendRoute]):
         func: Callable,
         query: Optional[ModelType],
         json: Optional[ModelType],
+        form: Optional[ModelType],
         headers: Optional[ModelType],
         cookies: Optional[ModelType],
         resp: Optional[Response],

--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     # to avoid cyclic import
     from ..spec import SpecTree
 
-Context = namedtuple("Context", ["query", "json", "headers", "cookies"])
+Context = namedtuple("Context", ["query", "json", "form", "headers", "cookies"])
 
 
 BackendRoute = TypeVar("BackendRoute")

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -132,7 +132,7 @@ class FlaskPlugin(BasePlugin):
 
         return "".join(subs), parameters
 
-    def request_validation(self, request, query, json, headers, cookies):
+    def request_validation(self, request, query, json, form_data, headers, cookies):
         """
         req_query: werkzeug.datastructures.ImmutableMultiDict
         req_json: dict
@@ -142,11 +142,13 @@ class FlaskPlugin(BasePlugin):
         req_query = get_multidict_items(request.args) or {}
         req_headers = dict(iter(request.headers)) or {}
         req_cookies = get_multidict_items(request.cookies) or {}
+        req_form = request.form or {}  # or MultiDict() ?
         use_json = json and request.method not in ("GET", "DELETE")
 
         request.context = Context(
             query.parse_obj(req_query) if query else None,
             json.parse_obj(self._fill_json(request)) if use_json else None,
+            form_data.parse_obj(req_form.items()) if form else None,
             headers.parse_obj(req_headers) if headers else None,
             cookies.parse_obj(req_cookies) if cookies else None,
         )
@@ -168,6 +170,7 @@ class FlaskPlugin(BasePlugin):
         func: Callable,
         query: Optional[ModelType],
         json: Optional[ModelType],
+        form_data,
         headers: Optional[ModelType],
         cookies: Optional[ModelType],
         resp: Optional[Response],

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -140,9 +140,9 @@ class FlaskPlugin(BasePlugin):
         req_cookies: werkzeug.datastructures.ImmutableMultiDict
         """
         req_query = get_multidict_items(request.args) or {}
+        req_form = request.form or {}  # or MultiDict() ?
         req_headers = dict(iter(request.headers)) or {}
         req_cookies = get_multidict_items(request.cookies) or {}
-        req_form = request.form or {}  # or MultiDict() ?
         use_json = json and request.method not in ("GET", "DELETE")
 
         request.context = Context(

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -27,6 +27,7 @@ def PydanticResponse(content):
 
 class StarlettePlugin(BasePlugin):
     ASYNC = True
+    FORM_MIMETYPE = ("application/x-www-form-urlencoded", "multipart/form-data")
 
     def __init__(self, spectree):
         super().__init__(spectree)
@@ -55,11 +56,11 @@ class StarlettePlugin(BasePlugin):
                 ),
             )
 
-    async def request_validation(self, request, query, json, headers, cookies):
-        use_json = json and request.method not in ("GET", "DELETE")
+    async def request_validation(self, request, query, json, form_data, headers, cookies):
         request.context = Context(
             query.parse_obj(request.query_params) if query else None,
             json.parse_raw(await request.body() or "{}") if use_json else None,
+            form_data.parse_obj(await response.form() or "{}") if form_data and data else None,
             headers.parse_obj(request.headers) if headers else None,
             cookies.parse_obj(request.cookies) if cookies else None,
         )
@@ -69,6 +70,7 @@ class StarlettePlugin(BasePlugin):
         func: Callable,
         query: Optional[ModelType],
         json: Optional[ModelType],
+        form_data,
         headers: Optional[ModelType],
         cookies: Optional[ModelType],
         resp: Optional[Response],

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -104,7 +104,7 @@ class SpecTree:
         self,
         query: Optional[ModelType] = None,
         json: Optional[ModelType] = None,
-        form_data=None,
+        form: Optional[ModelType] = None,
         headers: Optional[ModelType] = None,
         cookies: Optional[ModelType] = None,
         resp: Optional[Response] = None,

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -192,20 +192,17 @@ class SpecTree:
             )
 
             if self.config.annotations:
-                nonlocal query
+                nonlocal query, json, form, headers, cookies
                 query = func.__annotations__.get("query", query)
-                nonlocal json
                 json = func.__annotations__.get("json", json)
-                nonlocal form
                 form = func.__annotations__.get("form", form)
-                nonlocal headers
                 headers = func.__annotations__.get("headers", headers)
-                nonlocal cookies
                 cookies = func.__annotations__.get("cookies", cookies)
 
             # register
             for name, model in zip(
-                ("query", "json", "form", "headers", "cookies"), (query, json, form, headers, cookies)
+                ("query", "json", "form", "headers", "cookies"),
+                (query, json, form, headers, cookies),
             ):
                 if model is not None:
                     model_key = self._add_model(model=model)

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -104,6 +104,7 @@ class SpecTree:
         self,
         query: Optional[ModelType] = None,
         json: Optional[ModelType] = None,
+        form_data=None,
         headers: Optional[ModelType] = None,
         cookies: Optional[ModelType] = None,
         resp: Optional[Response] = None,
@@ -124,6 +125,7 @@ class SpecTree:
 
         :param query: `pydantic.BaseModel`, query in uri like `?name=value`
         :param json: `pydantic.BaseModel`, JSON format request body
+        :param form: `pydantic.BaseModel`, form-data request body
         :param headers: `pydantic.BaseModel`, if you have specific headers
         :param cookies: `pydantic.BaseModel`, if you have cookies for this route
         :param resp: `spectree.Response`
@@ -154,6 +156,7 @@ class SpecTree:
                     func,
                     query,
                     json,
+                    form,
                     headers,
                     cookies,
                     resp,
@@ -172,6 +175,7 @@ class SpecTree:
                     func,
                     query,
                     json,
+                    form,
                     headers,
                     cookies,
                     resp,
@@ -192,6 +196,8 @@ class SpecTree:
                 query = func.__annotations__.get("query", query)
                 nonlocal json
                 json = func.__annotations__.get("json", json)
+                nonlocal form
+                form = func.__annotations__.get("form", form)
                 nonlocal headers
                 headers = func.__annotations__.get("headers", headers)
                 nonlocal cookies
@@ -199,7 +205,7 @@ class SpecTree:
 
             # register
             for name, model in zip(
-                ("query", "json", "headers", "cookies"), (query, json, headers, cookies)
+                ("query", "json", "form", "headers", "cookies"), (query, json, form, headers, cookies)
             ):
                 if model is not None:
                     model_key = self._add_model(model=model)

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -63,24 +63,21 @@ def parse_request(func: Any) -> Dict[str, Any]:
     """
     get json spec
     """
-    data = {}
+    content_items = {}
     if hasattr(func, "json"):
-        data = {
-            "content": {
-                "application/json": {
-                    "schema": {"$ref": f"#/components/schemas/{func.json}"}
-                }
-            }
+        content_items["application/json"] = {
+            "schema": {"$ref": f"#/components/schemas/{func.json}"}
         }
-    elif hasattr(func, "form"):
-        data = {
-            "content": {
-                "multipart/form-data": {
-                    "schema": {"$ref": f"#/components/schemas/{func.form}"}
-                }
-            }
+
+    if hasattr(func, "form"):
+        content_items["multipart/form-data"] = {
+            "schema": {"$ref": f"#/components/schemas/{func.form}"}
         }
-    return data
+
+    if not content_items:
+        return {}
+
+    return {"content": content_items}
 
 
 def parse_params(
@@ -121,7 +118,7 @@ def parse_resp(func: Any):
     get the response spec
 
     If this function does not have explicit ``resp`` but have other models,
-    a ``422 Validation Error`` will be append to the response spec. Since
+    a ``422 Validation Error`` will be appended to the response spec, since
     this may be triggered in the validation step.
     """
     responses = {}
@@ -131,7 +128,7 @@ def parse_resp(func: Any):
     return responses
 
 
-def has_model(func: Any):
+def has_model(func: Any) -> bool:
     """
     return True if this function have ``pydantic.BaseModel``
     """

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -72,6 +72,14 @@ def parse_request(func: Any) -> Dict[str, Any]:
                 }
             }
         }
+    elif hasattr(func, "form"):
+        data = {
+            "content": {
+                "multipart/form-data": {
+                    "schema": {"$ref": f"#/components/schemas/{func.form}"}
+                }
+            }
+        }
     return data
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel, Field, root_validator
 
-from spectree import SecurityScheme, Tag
+from spectree import BaseFile, SecurityScheme, Tag
 from spectree.utils import hash_module_path
 
 api_tag = Tag(name="API", description="🐱", externalDocs={"url": "https://pypi.org"})
@@ -16,6 +16,15 @@ class Order(IntEnum):
 
 class Query(BaseModel):
     order: Order
+
+
+class FormFileUpload(BaseModel):
+    file: BaseFile
+
+
+class Form(BaseModel):
+    name: str
+    limit: str
 
 
 class JSON(BaseModel):

--- a/tests/flask_imports/__init__.py
+++ b/tests/flask_imports/__init__.py
@@ -3,7 +3,8 @@ from .dry_plugin_flask import (
     test_flask_no_response,
     test_flask_return_model,
     test_flask_skip_validation,
-    test_flask_validate,
+    test_flask_upload_file,
+    test_flask_validate_post_data,
     test_flask_validation_error_response_status_code,
 )
 
@@ -12,6 +13,7 @@ __all__ = [
     "test_flask_skip_validation",
     "test_flask_validation_error_response_status_code",
     "test_flask_doc",
-    "test_flask_validate",
+    "test_flask_validate_post_data",
     "test_flask_no_response",
+    "test_flask_upload_file",
 ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -54,6 +54,7 @@ def test_plugin_spec(api):
     ]
 
     assert get_paths(api.spec) == [
+        "/api/file_upload",
         "/api/no_response",
         "/api/user/{name}",
         "/api/user/{name}/address/{address_id}",

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -9,6 +9,8 @@ from .common import (
     JSON,
     SECURITY_SCHEMAS,
     Cookies,
+    Form,
+    FormFileUpload,
     Headers,
     Order,
     Query,
@@ -58,21 +60,33 @@ def ping():
     return jsonify(msg="pong")
 
 
+@app.route("/api/file_upload", methods=["POST"])
+@api.validate(
+    form=FormFileUpload,
+)
+def file_upload():
+    upload = request.context.form.file
+    assert upload
+    return {"content": upload.stream.read().decode("utf-8")}
+
+
 @app.route("/api/user/<name>", methods=["POST"])
 @api.validate(
     query=Query,
     json=JSON,
     cookies=Cookies,
+    form=Form,
     resp=Response(HTTP_200=Resp, HTTP_401=None),
     tags=[api_tag, "test"],
     after=api_after_handler,
 )
 def user_score(name):
-    score = [randint(0, request.context.json.limit) for _ in range(5)]
-    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    data_src = request.context.json or request.context.form
+    score = [randint(0, int(data_src.limit)) for _ in range(5)]
+    score.sort(reverse=(request.context.query.order == Order.desc))
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
-    return jsonify(name=request.context.json.name, score=score)
+    return jsonify(name=data_src.name, score=score)
 
 
 @app.route("/api/user_annotated/<name>", methods=["POST"])
@@ -81,12 +95,13 @@ def user_score(name):
     tags=[api_tag, "test"],
     after=api_after_handler,
 )
-def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
-    score = [randint(0, json.limit) for _ in range(5)]
-    score.sort(reverse=True if query.order == Order.desc else False)
+def user_score_annotated(name, query: Query, json: JSON, form: Form, cookies: Cookies):
+    data_src = json or form
+    score = [randint(0, int(data_src.limit)) for _ in range(5)]
+    score.sort(reverse=(query.order == Order.desc))
     assert cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
-    return jsonify(name=json.name, score=score)
+    return jsonify(name=data_src.name, score=score)
 
 
 @app.route("/api/user_skip/<name>", methods=["POST"])
@@ -101,7 +116,7 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies):
 )
 def user_score_skip_validation(name):
     score = [randint(0, request.context.json.limit) for _ in range(5)]
-    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    score.sort(reverse=(request.context.query.order == Order.desc))
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=request.context.json.name, x_score=score)
@@ -118,7 +133,7 @@ def user_score_skip_validation(name):
 )
 def user_score_model(name):
     score = [randint(0, request.context.json.limit) for _ in range(5)]
-    score.sort(reverse=True if request.context.query.order == Order.desc else False)
+    score.sort(reverse=(request.context.query.order == Order.desc))
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return Resp(name=request.context.json.name, score=score), 200


### PR DESCRIPTION
taking over where #185 was left. This is still very much WIP

- the previous PR made `form` and `json` exclusive (ie. only one can be defined at the time), which I dont think it should be enforced. Here's a use-case where we have right now: we have `/login/` endpoint, which can be called either from a legacy web which submits `<form>`, and it can be also used on a new frontend, which submits JSON payload. As such, one route can have both `form` and `json`.

- previous PR is adding usage of `cgi`, which is about to be deprecated, so it is again removed here
