### PR TITLE
refactoring: define flask tests in single place and reuse them

### DIFF
--- a/tests/flask_imports/__init__.py
+++ b/tests/flask_imports/__init__.py
@@ -1,0 +1,17 @@
+from .dry_plugin_flask import (
+    test_flask_doc,
+    test_flask_no_response,
+    test_flask_return_model,
+    test_flask_skip_validation,
+    test_flask_validate,
+    test_flask_validation_error_response_status_code,
+)
+
+__all__ = [
+    "test_flask_return_model",
+    "test_flask_skip_validation",
+    "test_flask_validation_error_response_status_code",
+    "test_flask_doc",
+    "test_flask_validate",
+    "test_flask_no_response",
+]

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -1,0 +1,148 @@
+import pytest
+
+
+def test_flask_skip_validation(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        "/api/user_skip/flask?order=1",
+        json=dict(name="flask", limit=10),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
+
+
+def test_flask_return_model(client):
+    client.set_cookie("flask", "pub", "abcdefg")
+
+    resp = client.post(
+        "/api/user_model/flask?order=1",
+        json=dict(name="flask", limit=10),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.headers.get("X-Validation") is None
+    assert resp.headers.get("X-API") == "OK"
+    assert resp.json["name"] == "flask"
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
+
+
+@pytest.mark.parametrize(
+    ["test_client_and_api", "expected_status_code"],
+    [
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {}},
+            422,
+            id="default-global-status-without-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
+            400,
+            id="default-global-status-with-override",
+        ),
+        pytest.param(
+            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
+            418,
+            id="overridden-global-status-without-override",
+        ),
+        pytest.param(
+            {
+                "api_kwargs": {"validation_error_status": 400},
+                "endpoint_kwargs": {"validation_error_status": 418},
+            },
+            418,
+            id="overridden-global-status-with-override",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_flask_validation_error_response_status_code(
+    test_client_and_api, expected_status_code
+):
+    app_client, _ = test_client_and_api
+
+    resp = app_client.get("/ping")
+
+    assert resp.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_client_and_api, expected_doc_pages",
+    [
+        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
+        pytest.param(
+            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
+            ["custom_page"],
+            id="custom-page-templates",
+        ),
+    ],
+    indirect=["test_client_and_api"],
+)
+def test_flask_doc(test_client_and_api, expected_doc_pages):
+    client, api = test_client_and_api
+
+    resp = client.get("/apidoc/openapi.json")
+    assert resp.json == api.spec
+
+    for doc_page in expected_doc_pages:
+        resp = client.get(f"/apidoc/{doc_page}/")
+        assert resp.status_code == 200
+
+        resp = client.get(f"/apidoc/{doc_page}")
+        assert resp.status_code == 308
+
+
+def test_flask_validate(client):
+    resp = client.get("/ping")
+    assert resp.status_code == 422
+    assert resp.headers.get("X-Error") == "Validation Error"
+
+    resp = client.get("/ping", headers={"lang": "en-US"})
+    assert resp.json == {"msg": "pong"}
+    assert resp.headers.get("X-Error") is None
+    assert resp.headers.get("X-Validation") == "Pass"
+
+    resp = client.post("api/user/flask")
+    assert resp.status_code == 422
+    assert resp.headers.get("X-Error") == "Validation Error"
+
+    client.set_cookie("flask", "pub", "abcdefg")
+    for fragment in ("user", "user_annotated"):
+        resp = client.post(
+            f"/api/{fragment}/flask?order=1",
+            json=dict(name="flask", limit=10),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.json
+        assert resp.headers.get("X-Validation") is None
+        assert resp.headers.get("X-API") == "OK"
+        assert resp.json["name"] == "flask"
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
+
+        resp = client.post(
+            f"/api/{fragment}/flask?order=0",
+            json=dict(name="flask", limit=10),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.json
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+        resp = client.post(
+            f"/api/{fragment}/flask?order=0",
+            data="name=flask&limit=10",
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.status_code == 200, resp.json
+        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+
+def test_flask_no_response(client):
+    resp = client.get("/api/no_response")
+    assert resp.status_code == 200, resp.data
+
+    resp = client.post("/api/no_response", data={"name": "foo", "limit": 1})
+    assert resp.status_code == 200, resp.data

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -1,4 +1,3 @@
-import json
 from random import randint
 
 import pytest
@@ -17,6 +16,9 @@ from .common import (
     StrDict,
     api_tag,
 )
+
+# import tests to execute
+from .flask_imports import *  # NOQA
 
 
 def before_handler(req, resp, err, _):
@@ -136,7 +138,7 @@ def user_address(name, address_id):
 
 @app.route("/api/no_response", methods=["GET", "POST"])
 @api.validate(
-    json=Query,
+    json=JSON,
 )
 def no_response():
     return {}
@@ -154,80 +156,6 @@ api.register(app)
 def client():
     with app.test_client() as client:
         yield client
-
-
-def test_flask_validate(client):
-    resp = client.get("/ping")
-    assert resp.status_code == 422
-    assert resp.headers.get("X-Error") == "Validation Error"
-
-    resp = client.get("/ping", headers={"lang": "en-US"})
-    assert resp.json == {"msg": "pong"}
-    assert resp.headers.get("X-Error") is None
-    assert resp.headers.get("X-Validation") == "Pass"
-
-    resp = client.post("api/user/flask")
-    assert resp.status_code == 422
-    assert resp.headers.get("X-Error") == "Validation Error"
-
-    client.set_cookie("flask", "pub", "abcdefg")
-    for fragment in ("user", "user_annotated"):
-        resp = client.post(
-            f"/api/{fragment}/flask?order=1",
-            data=json.dumps(dict(name="flask", limit=10)),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200, resp.json
-        assert resp.headers.get("X-Validation") is None
-        assert resp.headers.get("X-API") == "OK"
-        assert resp.json["name"] == "flask"
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
-
-        resp = client.post(
-            f"/api/{fragment}/flask?order=0",
-            data=json.dumps(dict(name="flask", limit=10)),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200, resp.json
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
-
-        resp = client.post(
-            f"/api/{fragment}/flask?order=0",
-            data="name=flask&limit=10",
-            content_type="application/x-www-form-urlencoded",
-        )
-        assert resp.status_code == 200, resp.json
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
-
-
-def test_flask_skip_validation(client):
-    client.set_cookie("flask", "pub", "abcdefg")
-
-    resp = client.post(
-        "/api/user_skip/flask?order=1",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.headers.get("X-Validation") is None
-    assert resp.headers.get("X-API") == "OK"
-    assert resp.json["name"] == "flask"
-    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
-
-
-def test_flask_return_model(client):
-    client.set_cookie("flask", "pub", "abcdefg")
-
-    resp = client.post(
-        "/api/user_model/flask?order=1",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.headers.get("X-Validation") is None
-    assert resp.headers.get("X-API") == "OK"
-    assert resp.json["name"] == "flask"
-    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
 
 
 @pytest.fixture
@@ -265,71 +193,6 @@ def test_client_and_api(request):
 
     with app.test_client() as test_client:
         yield test_client, api
-
-
-@pytest.mark.parametrize(
-    "test_client_and_api, expected_status_code",
-    [
-        pytest.param(
-            {"api_kwargs": {}, "endpoint_kwargs": {}},
-            422,
-            id="default-global-status-without-override",
-        ),
-        pytest.param(
-            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
-            400,
-            id="default-global-status-with-override",
-        ),
-        pytest.param(
-            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
-            418,
-            id="overridden-global-status-without-override",
-        ),
-        pytest.param(
-            {
-                "api_kwargs": {"validation_error_status": 400},
-                "endpoint_kwargs": {"validation_error_status": 418},
-            },
-            418,
-            id="overridden-global-status-with-override",
-        ),
-    ],
-    indirect=["test_client_and_api"],
-)
-def test_validation_error_response_status_code(
-    test_client_and_api, expected_status_code
-):
-    app_client, _ = test_client_and_api
-
-    resp = app_client.get("/ping")
-
-    assert resp.status_code == expected_status_code
-
-
-@pytest.mark.parametrize(
-    "test_client_and_api, expected_doc_pages",
-    [
-        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
-        pytest.param(
-            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
-            ["custom_page"],
-            id="custom-page-templates",
-        ),
-    ],
-    indirect=["test_client_and_api"],
-)
-def test_flask_doc(test_client_and_api, expected_doc_pages):
-    client, api = test_client_and_api
-
-    resp = client.get("/apidoc/openapi.json")
-    assert resp.json == api.spec
-
-    for doc_page in expected_doc_pages:
-        resp = client.get(f"/apidoc/{doc_page}/")
-        assert resp.status_code == 200
-
-        resp = client.get(f"/apidoc/{doc_page}")
-        assert resp.status_code == 308
 
 
 """

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -1,4 +1,3 @@
-import json
 from random import randint
 
 import pytest
@@ -8,6 +7,9 @@ from flask.views import MethodView
 from spectree import Response, SpecTree
 
 from .common import JSON, Cookies, Headers, Order, Query, Resp, StrDict, api_tag
+
+# import tests to execute
+from .flask_imports import *  # NOQA
 
 
 def before_handler(req, resp, err, _):
@@ -125,9 +127,9 @@ class NoResponseView(MethodView):
         return {}
 
     @api.validate(
-        json=Query,  # resp is missing completely
+        json=JSON,  # resp is missing completely
     )
-    def post(self, json: Query):
+    def post(self, json: JSON):
         return {}
 
 
@@ -174,84 +176,6 @@ def client():
         yield client
 
 
-def test_flask_validate(client):
-    resp = client.get("/ping")
-    assert resp.status_code == 422
-    assert resp.headers.get("X-Error") == "Validation Error"
-
-    resp = client.get("/ping", headers={"lang": "en-US"})
-    assert resp.json == {"msg": "pong"}
-    assert resp.headers.get("X-Error") is None
-    assert resp.headers.get("X-Validation") == "Pass"
-
-    resp = client.post("api/user/flask")
-    assert resp.status_code == 422
-    assert resp.headers.get("X-Error") == "Validation Error"
-
-    client.set_cookie("flask", "pub", "abcdefg")
-    for fragment in ("user", "user_annotated"):
-        resp = client.post(
-            f"/api/{fragment}/flask?order=1",
-            data=json.dumps(dict(name="flask", limit=10)),
-            content_type="application/json",
-        )
-        assert resp.status_code == 200, resp.json
-        assert resp.headers.get("X-Validation") is None
-        assert resp.headers.get("X-API") == "OK"
-        assert resp.json["name"] == "flask"
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
-
-        resp = client.post(
-            f"/api/{fragment}/flask?order=0",
-            data=json.dumps(dict(name="flask", limit=10)),
-            content_type="application/json",
-        )
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
-
-        resp = client.post(
-            f"/api/{fragment}/flask?order=0",
-            data="name=flask&limit=10",
-            content_type="application/x-www-form-urlencoded",
-        )
-        assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
-
-    resp = client.get("/api/no_response")
-    assert resp.status_code == 200
-
-    resp = client.post("/api/no_response", data={"order": 1})
-    assert resp.status_code == 200
-
-
-def test_flask_skip_validation(client):
-    client.set_cookie("flask", "pub", "abcdefg")
-
-    resp = client.post(
-        "/api/user_skip/flask?order=1",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.headers.get("X-Validation") is None
-    assert resp.headers.get("X-API") == "OK"
-    assert resp.json["name"] == "flask"
-    assert resp.json["x_score"] == sorted(resp.json["x_score"], reverse=True)
-
-
-def test_flask_return_model(client):
-    client.set_cookie("flask", "pub", "abcdefg")
-
-    resp = client.post(
-        "/api/user_model/flask?order=1",
-        data=json.dumps(dict(name="flask", limit=10)),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.headers.get("X-Validation") is None
-    assert resp.headers.get("X-API") == "OK"
-    assert resp.json["name"] == "flask"
-    assert resp.json["score"] == sorted(resp.json["score"], reverse=True)
-
-
 @pytest.fixture
 def test_client_and_api(request):
     api_args = ["flask"]
@@ -289,68 +213,3 @@ def test_client_and_api(request):
 
     with app.test_client() as test_client:
         yield test_client, api
-
-
-@pytest.mark.parametrize(
-    "test_client_and_api, expected_status_code",
-    [
-        pytest.param(
-            {"api_kwargs": {}, "endpoint_kwargs": {}},
-            422,
-            id="default-global-status-without-override",
-        ),
-        pytest.param(
-            {"api_kwargs": {}, "endpoint_kwargs": {"validation_error_status": 400}},
-            400,
-            id="default-global-status-with-override",
-        ),
-        pytest.param(
-            {"api_kwargs": {"validation_error_status": 418}, "endpoint_kwargs": {}},
-            418,
-            id="overridden-global-status-without-override",
-        ),
-        pytest.param(
-            {
-                "api_kwargs": {"validation_error_status": 400},
-                "endpoint_kwargs": {"validation_error_status": 418},
-            },
-            418,
-            id="overridden-global-status-with-override",
-        ),
-    ],
-    indirect=["test_client_and_api"],
-)
-def test_validation_error_response_status_code(
-    test_client_and_api, expected_status_code
-):
-    app_client, _ = test_client_and_api
-
-    resp = app_client.get("/ping")
-
-    assert resp.status_code == expected_status_code
-
-
-@pytest.mark.parametrize(
-    "test_client_and_api, expected_doc_pages",
-    [
-        pytest.param({}, ["redoc", "swagger"], id="default-page-templates"),
-        pytest.param(
-            {"api_kwargs": {"page_templates": {"custom_page": "{spec_url}"}}},
-            ["custom_page"],
-            id="custom-page-templates",
-        ),
-    ],
-    indirect=["test_client_and_api"],
-)
-def test_flask_doc(test_client_and_api, expected_doc_pages):
-    client, api = test_client_and_api
-
-    resp = client.get("/apidoc/openapi.json")
-    assert resp.json == api.spec
-
-    for doc_page in expected_doc_pages:
-        resp = client.get(f"/apidoc/{doc_page}/")
-        assert resp.status_code == 200
-
-        resp = client.get(f"/apidoc/{doc_page}")
-        assert resp.status_code == 308


### PR DESCRIPTION
Moreless identical tests for Flask plugin are written in three different files now (`test_plugin_flask.py`, `test_plugin_flask_view.py`, `test_plugin_flask_blueprint.py`). This PR put them into single places from where they can be imported into each respective test file.

This revealed that the `no_response` view was not tested properly everywhere (see #226), so until that will be resolved, the parameter `json=Query` for given view is commented out.