### PR TITLE
fix: dont validate JSON data in request which cant provide it

### DIFF
--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -56,9 +56,10 @@ class StarlettePlugin(BasePlugin):
             )
 
     async def request_validation(self, request, query, json, headers, cookies):
+        use_json = json and request.method not in ("GET", "DELETE")
         request.context = Context(
             query.parse_obj(request.query_params) if query else None,
-            json.parse_raw(await request.body() or "{}") if json else None,
+            json.parse_raw(await request.body() or "{}") if use_json else None,
             headers.parse_obj(request.headers) if headers else None,
             cookies.parse_obj(request.cookies) if cookies else None,
         )

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -320,7 +320,7 @@ def test_validation_error_response_status_code(
     ],
     indirect=["test_client_and_api"],
 )
-def test_flask_doc(test_client_and_api, expected_doc_pages):
+def test_starlette_doc(test_client_and_api, expected_doc_pages):
     client, api = test_client_and_api
 
     resp = client.get("/apidoc/openapi.json")
@@ -329,3 +329,11 @@ def test_flask_doc(test_client_and_api, expected_doc_pages):
     for doc_page in expected_doc_pages:
         resp = client.get(f"/apidoc/{doc_page}")
         assert resp.status_code == 200
+
+
+def test_starlette_no_response(client):
+    resp = client.get("/api/no_response")
+    assert resp.status_code == 200, resp.text
+
+    resp = client.post("/api/no_response", json={"name": "starlette", "limit": 1})
+    assert resp.status_code == 200, resp.text


### PR DESCRIPTION
this should fix #226

- falcon plugin not affected, since there seems to be only class-based views with split GET and POST dispatchers

- flask tests not changed, as I hope #227 can be merged eventually