### PR TITLE
Make email-validator an optional dependency

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,6 +41,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          pip install -e .[flask,falcon,starlette]
       - name: Test
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ check: lint test
 SOURCE_FILES=spectree tests examples setup.py
 
 install:
-	pip install -e .[flask,falcon,starlette,dev]
+	pip install -e .[email,flask,falcon,starlette,dev]
 
 test:
 	pip install falcon --upgrade

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,10 @@ install:
 	pip install -e .[email,flask,falcon,starlette,dev]
 
 test:
-	pip install falcon --upgrade
-	pytest tests -vv
-	pip uninstall falcon -y && pip install falcon==2.0.0
-	pytest tests -vv
-
+	pip install -U -e .[email,flask,falcon,starlette]
+	pytest tests -vv -rs
+	pip uninstall falcon email-validator -y && pip install falcon==2.0.0
+	pytest tests -vv -rs
 doc:
 	cd docs && make html
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Yet another library to generate OpenAPI documents and validate requests & respon
 
 ## Quick Start
 
-install with pip: `pip install spectree`
+Install with pip: `pip install spectree`. If you'd like for email fields to be validated, use `pip install spectree[email]`.
 
 ### Examples
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,8 @@ Features
 Quick Start
 -----------
 
-install with pip: ``pip install spectree``
+Install with pip: ``pip install spectree``. If you'd like for email fields to be validated, use ``pip install spectree[email]``.
+
 
 Examples
 ~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydantic[email]>=1.2
+pydantic>=1.2

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     python_requires=">=3.6",
     install_requires=requires,
     extras_require={
+        "email": ["pydantic[email]>=1.2"],
         "flask": ["flask"],
         "falcon": ["falcon"],
         "starlette": ["starlette[full]"],

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -1,11 +1,21 @@
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
 
 from pydantic import AnyUrl, BaseModel, BaseSettings, EmailStr, root_validator
 
 from .models import SecurityScheme, Server
 from .page import DEFAULT_PAGE_TEMPLATES
+
+# Fall back to a str field if email-validator is not installed.
+if TYPE_CHECKING:
+    EmailFieldType = str
+else:
+    try:
+        EmailStr.validate("a@b.com")
+        EmailFieldType = EmailStr
+    except ImportError:
+        EmailFieldType = str
 
 
 class ModeEnum(str, Enum):
@@ -27,7 +37,7 @@ class Contact(BaseModel):
     #: contact url
     url: Optional[AnyUrl] = None
     #: contact email address
-    email: Optional[EmailStr] = None
+    email: Optional[EmailFieldType] = None
 
 
 class License(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from spectree import SecurityScheme
-from spectree.config import Configuration
+from spectree.config import Configuration, EmailFieldType
 
 from .common import SECURITY_SCHEMAS, WRONG_SECURITY_SCHEMAS_DATA
 
@@ -39,8 +39,11 @@ def test_config_contact():
     with pytest.raises(ValidationError):
         config = Configuration(contact={"name": "John", "url": "url"})
 
+
+@pytest.mark.skipif(EmailFieldType == str, reason="email-validator is not installled")
+def test_config_contact_invalid_email():
     with pytest.raises(ValidationError):
-        config = Configuration(contact={"name": "John", "email": "hello"})
+        Configuration(contact={"name": "John", "email": "hello"})
 
 
 def test_config_case():


### PR DESCRIPTION
Resolve #235

It can be installed with `pip install spectree[email]`. Otherwise, fall back to using a `str` as the type of the email field in the contact model of the config.