### PR TITLE
fix: use mypy.ignore_missing_imports instead of suppressing them everywhere manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
 	flake8 ${SOURCE_FILES} --count --show-source --statistics
-	mypy --install-types --non-interactive --show-error-codes --warn-unused-ignores --disable-error-code attr-defined ${SOURCE_FILES}
+	mypy --install-types --non-interactive ${SOURCE_FILES}
 
 .PHONY: test doc

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -2,7 +2,7 @@ import logging
 from random import random
 from wsgiref import simple_server
 
-import falcon  # type: ignore
+import falcon
 from pydantic import BaseModel, Field
 
 from spectree import Response, SpecTree, Tag

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -1,4 +1,4 @@
-import uvicorn  # type: ignore
+import uvicorn
 from pydantic import BaseModel, Field
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = true
+show_error_codes = true
+warn_unused_ignores = true
+disable_error_code = attr-defined

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -55,8 +55,8 @@ class FalconPlugin(BasePlugin):
     def __init__(self, spectree):
         super().__init__(spectree)
 
-        from falcon import HTTP_400, HTTP_415, HTTPError  # type: ignore
-        from falcon.routing.compiled import _FIELD_PATTERN  # type: ignore
+        from falcon import HTTP_400, HTTP_415, HTTPError
+        from falcon.routing.compiled import _FIELD_PATTERN
 
         # used to detect falcon 3.0 request media parse error
         self.FALCON_HTTP_ERROR = HTTPError

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -194,7 +194,8 @@ class FlaskPlugin(BasePlugin):
         before(request, response, req_validation_error, None)
         if req_validation_error:
             after(request, response, req_validation_error, None)
-            abort(response)  # type: ignore
+            assert response  # make mypy happy
+            abort(response)
 
         result = func(*args, **kwargs)
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -3,7 +3,7 @@ from random import randint
 try:
     from falcon import App
 except ImportError:
-    from falcon import API as App  # type: ignore
+    from falcon import API as App
 
 import pytest
 from falcon import testing

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -1,14 +1,14 @@
 from random import randint
 
 import pytest
-from falcon import testing  # type: ignore
+from falcon import testing
 
 from spectree import Response, SpecTree
 
 from .common import JSON, Cookies, Headers, Query, Resp, StrDict, api_tag
 
 pytest.importorskip("falcon", minversion="3.0.0", reason="Missing required Falcon 3.0")
-from falcon.asgi import App  # type: ignore # noqa: E402
+from falcon.asgi import App  # noqa: E402
 
 
 def before_handler(req, resp, err, instance):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,7 +1,7 @@
 try:
     from falcon import App as FalconApp
 except ImportError:
-    from falcon import API as FalconApp  # type: ignore
+    from falcon import API as FalconApp
 
 import pytest
 from flask import Flask


### PR DESCRIPTION
seems like these mypy errors are the last thing making the pipeline fail in #225. Instead of adding `type: ignore` to all newly added imports there, it would be better to disable these errors in one place. This PR is doing that.

`ignore_missing_imports` description in mypy docs:
https://mypy.readthedocs.io/en/stable/config_file.html#confval-ignore_missing_imports

- config options are moved into its config file instead of calling them manually