### PR TITLE
drop support for Falcon 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ install:
 test:
 	pip install -U -e .[email,flask,falcon,starlette]
 	pytest tests -vv -rs
-	pip uninstall falcon email-validator -y && pip install falcon==2.0.0
-	pytest tests -vv -rs
 doc:
 	cd docs && make html
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Yet another library to generate OpenAPI documents and validate requests & respon
 * Validate query, JSON data, response data with [pydantic](https://github.com/samuelcolvin/pydantic/) :wink:
 * Current support:
   * Flask [demo](#flask)
-  * Falcon [demo](#falcon) (including ASGI under Falcon 3+)
+  * Falcon [demo](#falcon) (including ASGI)
   * Starlette [demo](#starlette)
 
 ## Quick Start
@@ -54,7 +54,7 @@ If the request doesn't pass the validation, it will return a 422 with a JSON err
 
 ### Falcon response validation
 
-For falcon response, this library only validates against media as it is the serializable object. Response.body(deprecated in falcon 3.0 and replaced by text) is a string representing response content and will not be validated. For no assigned media situation, `resp` parameter in `api.validate` should be like `Response(HTTP_200=None)`
+For Falcon response, this library only validates against media as it is the serializable object. Response.text is a string representing response content and will not be validated. For no assigned media situation, `resp` parameter in `api.validate` should be like `Response(HTTP_200=None)`
 
 ### Opt-in type annotation feature
 This library also supports the injection of validated fields into view function arguments along with parameter annotation-based type declaration. This works well with linters that can take advantage of typing features like mypy. See the examples section below.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Yet another library to generate OpenAPI documents and validate requests & respon
 * Validate query, JSON data, response data with [pydantic](https://github.com/samuelcolvin/pydantic/) :wink:
 * Current support:
   * Flask [demo](#flask)
-  * Falcon [demo](#falcon) (including ASGI)
+  * Falcon [demo](#falcon)
   * Starlette [demo](#starlette)
 
 ## Quick Start

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         http :8000/ping
         http ':8000/api/zh/en?text=hi' uid=neo limit=1 vip=true
     """
-    app = falcon.API()
+    app = falcon.App()
     app.add_route("/ping", Ping())
     app.add_route("/api/{source}/{target}", Classification())
     api.register(app)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     extras_require={
         "email": ["pydantic[email]>=1.2"],
         "flask": ["flask", "werkzeug<2.2"],
-        "falcon": ["falcon"],
+        "falcon": ["falcon>=3.0.0"],
         "starlette": ["starlette[full]"],
         "dev": [
             "pytest~=7.1",

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -24,11 +24,7 @@ class DocPage:
 
     def on_get(self, _: Any, resp: Any):
         resp.content_type = "text/html"
-        # resp.body is deprecated in Falcon 3
-        if hasattr(resp, "text"):
-            resp.text = self.page
-        else:
-            resp.body = self.page
+        resp.text = self.page
 
 
 class OpenAPIAsgi(OpenAPI):

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -54,7 +54,6 @@ class FalconPlugin(BasePlugin):
         from falcon import HTTP_400, HTTP_415, HTTPError
         from falcon.routing.compiled import _FIELD_PATTERN
 
-        # used to detect falcon 3.0 request media parse error
         self.FALCON_HTTP_ERROR = HTTPError
         self.FALCON_MEDIA_ERROR_CODE = (HTTP_400, HTTP_415)
         self.FIELD_PATTERN = _FIELD_PATTERN

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -1,12 +1,7 @@
 from random import randint
 
-try:
-    from falcon import App
-except ImportError:
-    from falcon import API as App
-
 import pytest
-from falcon import testing
+from falcon import App, testing
 
 from spectree import Response, SpecTree
 

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -2,13 +2,11 @@ from random import randint
 
 import pytest
 from falcon import testing
+from falcon.asgi import App
 
 from spectree import Response, SpecTree
 
 from .common import JSON, Cookies, Headers, Query, Resp, StrDict, api_tag
-
-pytest.importorskip("falcon", minversion="3.0.0", reason="Missing required Falcon 3.0")
-from falcon.asgi import App  # noqa: E402
 
 
 def before_handler(req, resp, err, instance):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,9 +1,5 @@
-try:
-    from falcon import App as FalconApp
-except ImportError:
-    from falcon import API as FalconApp
-
 import pytest
+from falcon import App as FalconApp
 from flask import Flask
 from pydantic import BaseModel
 from starlette.applications import Starlette


### PR DESCRIPTION
moreless copy-paste of my comment here: https://github.com/0b01001001/spectree/pull/225#issuecomment-1192452387

Falcon 2 was released 2019 and never got any patch above 2.0.0 (see https://pypi.org/project/falcon/#history ), so it seems unsupported anyway.

The reason why I would propse doing this is that Falcon 2 does not support form data. The pipeline in #225 fails right now because `get_media()` does not exist in Falcon 2, so I tried to use `req.media` instead, and I got the following error (with Falcon 2)
```
AssertionError: {"title": "Unsupported media type", "description": "multipart/form-data is an unsupported media type."}
```

Dropping Falcon 2 would then make implementing the form data support easier.