### PR TITLE
hotfix: add bound for werkzeug dependency due to breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=requires,
     extras_require={
         "email": ["pydantic[email]>=1.2"],
-        "flask": ["flask"],
+        "flask": ["flask", "werkzeug<2.2"],
         "falcon": ["falcon"],
         "starlette": ["starlette[full]"],
         "dev": [


### PR DESCRIPTION
Werkzeug 2.2 has marked `parse_rule` as internal so it cant be imported anymore. This function is used in Flask plugin.

See failing pipeline: https://github.com/0b01001001/spectree/actions/runs/2751022576

See their relevant issue: https://github.com/pallets/werkzeug/issues/2464


Adding bounded werkzeug dependency should fix it for now