### PR TITLE
add copy of `werkzeug.parse_rule` which is now marked as internal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=requires,
     extras_require={
         "email": ["pydantic[email]>=1.2"],
-        "flask": ["flask", "werkzeug<2.2"],
+        "flask": ["flask"],
         "falcon": ["falcon>=3.0.0"],
         "starlette": ["starlette[full]"],
         "dev": [

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ValidationError
 
 from .._types import ModelType
 from ..response import Response
-from ..utils import get_multidict_items
+from ..utils import get_multidict_items, werkzeug_parse_rule
 from .base import BasePlugin, Context
 
 
@@ -59,12 +59,12 @@ class FlaskPlugin(BasePlugin):
                 yield method, func
 
     def parse_path(self, route, path_parameter_descriptions):
-        from werkzeug.routing import parse_converter_args, parse_rule
+        from werkzeug.routing import parse_converter_args
 
         subs = []
         parameters = []
 
-        for converter, arguments, variable in parse_rule(str(route)):
+        for converter, arguments, variable in werkzeug_parse_rule(str(route)):
             if converter is None:
                 subs.append(variable)
                 continue

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -243,15 +243,15 @@ class SpecTree:
         tags = {}
         for route in self.backend.find_routes():
             for method, func in self.backend.parse_func(route):
+                if self.backend.bypass(func, method) or self.bypass(func):
+                    continue
+
                 path_parameter_descriptions = getattr(
                     func, "path_parameter_descriptions", None
                 )
                 path, parameters = self.backend.parse_path(
                     route, path_parameter_descriptions
                 )
-
-                if self.backend.bypass(func, method) or self.bypass(func):
-                    continue
 
                 name = parse_name(func)
                 summary, desc = parse_comments(func)

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -21,6 +22,22 @@ from ._types import ModelType, MultiDict
 
 # parse HTTP status code to get the code
 HTTP_CODE = re.compile(r"^HTTP_(?P<code>\d{3})$")
+
+RE_FLASK_RULE = re.compile(
+    r"""
+    (?P<static>[^<]*)                           # static rule data
+    <
+    (?:
+        (?P<converter>[a-zA-Z_][a-zA-Z0-9_]*)   # converter name
+        (?:\((?P<args>.*?)\))?                  # converter arguments
+        \:                                      # variable delimiter
+    )?
+    (?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)        # variable name
+    >
+    """,
+    re.VERBOSE,
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -277,3 +294,37 @@ def gen_list_model(model: Type[BaseModel]) -> Type[BaseModel]:
         },
     )
     return ListModel
+
+
+def werkzeug_parse_rule(
+    rule: str,
+) -> Iterator[Tuple[Optional[str], Optional[str], str]]:
+    """A copy of werkzeug.parse_rule which is now removed.
+
+    Parse a rule and return it as generator. Each iteration yields tuples
+    in the form ``(converter, arguments, variable)``. If the converter is
+    `None` it's a static url part, otherwise it's a dynamic one.
+    """
+    pos = 0
+    end = len(rule)
+    do_match = RE_FLASK_RULE.match
+    used_names = set()
+    while pos < end:
+        m = do_match(rule, pos)
+        if m is None:
+            break
+        data = m.groupdict()
+        if data["static"]:
+            yield None, None, data["static"]
+        variable = data["variable"]
+        converter = data["converter"] or "default"
+        if variable in used_names:
+            raise ValueError(f"variable name {variable!r} used twice.")
+        used_names.add(variable)
+        yield converter, data["args"] or None, variable
+        pos = m.end()
+    if pos < end:
+        remaining = rule[pos:]
+        if ">" in remaining or "<" in remaining:
+            raise ValueError(f"malformed url rule: {rule!r}")
+        yield None, None, remaining


### PR DESCRIPTION
I did dig a bit into new Werkzeug and didnt figure out a way how to replace `parse_rule`, so it seems like the fastest way how to make it work is to keep own copy of `parse_rule`.
 
plus there's microoptimization in separate commit to do `bypass()` before some route parsing