### PR TITLE
Use typing.get_type_hints instead of .__annotations__

### DIFF
--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from functools import partial
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional, get_type_hints
 
 from pydantic import ValidationError
 
@@ -212,8 +212,9 @@ class FalconPlugin(BasePlugin):
         try:
             self.request_validation(_req, query, json, headers, cookies)
             if self.config.annotations:
+                annotations = get_type_hints(func)
                 for name in ("query", "json", "headers", "cookies"):
-                    if func.__annotations__.get(name):
+                    if annotations.get(name):
                         kwargs[name] = getattr(_req.context, name)
 
         except ValidationError as err:
@@ -293,8 +294,9 @@ class FalconAsgiPlugin(FalconPlugin):
         try:
             await self.request_validation(_req, query, json, headers, cookies)
             if self.config.annotations:
+                annotations = get_type_hints(func)
                 for name in ("query", "json", "headers", "cookies"):
-                    if func.__annotations__.get(name):
+                    if annotations.get(name):
                         kwargs[name] = getattr(_req.context, name)
 
         except ValidationError as err:

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, get_type_hints
 
 from pydantic import BaseModel, ValidationError
 
@@ -184,8 +184,9 @@ class FlaskPlugin(BasePlugin):
         try:
             self.request_validation(request, query, json, headers, cookies)
             if self.config.annotations:
+                annotations = get_type_hints(func)
                 for name in ("query", "json", "headers", "cookies"):
-                    if func.__annotations__.get(name):
+                    if annotations.get(name):
                         kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -2,7 +2,7 @@ import inspect
 from collections import namedtuple
 from functools import partial
 from json import JSONDecodeError
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, get_type_hints
 
 from pydantic import ValidationError
 
@@ -93,8 +93,9 @@ class StarlettePlugin(BasePlugin):
         try:
             await self.request_validation(request, query, json, headers, cookies)
             if self.config.annotations:
+                annotations = get_type_hints(func)
                 for name in ("query", "json", "headers", "cookies"):
-                    if func.__annotations__.get(name):
+                    if annotations.get(name):
                         kwargs[name] = getattr(request.context, name)
         except ValidationError as err:
             req_validation_error = err

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -1,7 +1,16 @@
 from collections import defaultdict
 from copy import deepcopy
 from functools import wraps
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    get_type_hints,
+)
 
 from ._types import FunctionDecorator, ModelType
 from .config import Configuration, ModeEnum

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from copy import deepcopy
 from functools import wraps
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Type, get_type_hints
 
 from ._types import FunctionDecorator, ModelType
 from .config import Configuration, ModeEnum
@@ -188,14 +188,15 @@ class SpecTree:
             )
 
             if self.config.annotations:
+                annotations = get_type_hints(func)
                 nonlocal query
-                query = func.__annotations__.get("query", query)
+                query = annotations.get("query", query)
                 nonlocal json
-                json = func.__annotations__.get("json", json)
+                json = annotations.get("json", json)
                 nonlocal headers
-                headers = func.__annotations__.get("headers", headers)
+                headers = annotations.get("headers", headers)
                 nonlocal cookies
-                cookies = func.__annotations__.get("cookies", cookies)
+                cookies = annotations.get("cookies", cookies)
 
             # register
             for name, model in zip(


### PR DESCRIPTION
https://docs.python.org/3/library/typing.html#typing.get_type_hints

This properly resolves forward annotations, and fixes annotations when
 code uses `from __future__ import annotations`

Cherry-picked to `before_v1` to help you out :)

I'd super appreciate a minor version or bugfix release with this