### PR TITLE
added possibility to set any func name to openapi docs for falcon ASGI/WSGI.

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -114,6 +114,7 @@ class SpecTree:
         query: Optional[ModelType] = None,
         json: Optional[ModelType] = None,
         form: Optional[ModelType] = None,
+        openapi_name: Optional[str] = 'Void_Method',
         headers: Optional[ModelType] = None,
         cookies: Optional[ModelType] = None,
         resp: Optional[Response] = None,
@@ -135,6 +136,7 @@ class SpecTree:
         :param query: `pydantic.BaseModel`, query in uri like `?name=value`
         :param json: `pydantic.BaseModel`, JSON format request body
         :param form: `pydantic.BaseModel`, form-data request body
+        :param openapi_name: A string name of function in docs
         :param headers: `pydantic.BaseModel`, if you have specific headers
         :param cookies: `pydantic.BaseModel`, if you have cookies for this route
         :param resp: `spectree.Response`
@@ -166,6 +168,7 @@ class SpecTree:
                     query,
                     json,
                     form,
+                    openapi_name,
                     headers,
                     cookies,
                     resp,
@@ -185,6 +188,7 @@ class SpecTree:
                     query,
                     json,
                     form,
+                    openapi_name,
                     headers,
                     cookies,
                     resp,
@@ -231,6 +235,7 @@ class SpecTree:
 
             validation.security = security
             validation.deprecated = deprecated
+            validation.openapi_name = openapi_name
             validation.path_parameter_descriptions = path_parameter_descriptions
             # register decorator
             validation._decorator = self

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -176,7 +176,7 @@ def parse_name(func: Callable[..., Any]) -> str:
         * decorated functions
         * decorated class methods
     """
-    return func.__name__
+    return func.openapi_name
 
 
 def default_before_handler(


### PR DESCRIPTION
added small changes to falcon plugin wsgi/asgi, because redoc docs look not good with standart falcon func naming like on_post / on_get. if it need any improvements in code style or others, tell it pls, it will be done.