### PR TITLE
AND/OR root security configuration

### DIFF
--- a/examples/security_demo.py
+++ b/examples/security_demo.py
@@ -45,7 +45,10 @@ app = Flask(__name__)
 spec = SpecTree(
     "flask",
     security_schemes=security_schemes,
-    SECURITY={"test_secure": []},
+    SECURITY=[
+        {"test_secure": []},
+        {"PartnerID": [], "PartnerToken": []},
+    ],
     client_id="client_id",
 )
 
@@ -53,9 +56,17 @@ spec = SpecTree(
 @app.route("/ping", methods=["POST"])
 @spec.validate(
     json=Req,
-    security=[{"PartnerID": [], "PartnerToken": []}, {"auth_oauth2": ["read"]}],
 )
 def ping():
+    return "pong"
+
+
+@app.route("/ping/oauth", methods=["POST"])
+@spec.validate(
+    json=Req,
+    security=[{"auth_oauth2": ["read"]}],
+)
+def oauth_only():
     return "pong"
 
 

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, BaseSettings, EmailStr, root_validator
 
@@ -86,7 +86,7 @@ class Configuration(BaseSettings):
     #: OpenAPI `securitySchemes` :py:class:`spectree.models.SecurityScheme`
     security_schemes: Optional[List[SecurityScheme]] = None
     #: OpenAPI `security` JSON at the global level
-    security: Dict = {}
+    security: Union[Dict[str, List[str]], List[Dict[str, List[str]]]] = {}
     # Swagger OAuth2 configs
     #: OAuth2 client id
     client_id: str = ""


### PR DESCRIPTION
We have multiple security options available to our whole API,
 and this allows us to set that. It also does basic validation
 of the `security` dict

Signed-off-by: Franklyn Tackitt <franklyn@tackitt.net>