### PR TITLE
fix: only call `after` at the end of the validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, "requirements.txt"), encoding="utf-8") as f:
 
 setup(
     name="spectree",
-    version="1.0.0a3",
+    version="1.0.0a4",
     license="Apache-2.0",
     author="Keming Yang",
     author_email="kemingy94@gmail.com",

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -193,7 +193,6 @@ class FlaskPlugin(BasePlugin):
 
         before(request, response, req_validation_error, None)
         if req_validation_error:
-            after(request, response, req_validation_error, None)
             assert response  # make mypy happy
             abort(response)
 


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* fix https://github.com/0b01001001/spectree/issues/273