### PR TITLE
Allow endpoints to override its operationId

### DIFF
--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -216,3 +216,23 @@ def test_global_model_for_validation_errors_specified():
 
     assert foo.resp.find_model(422) is GlobalValidationError
     assert bar.resp.find_model(422) is RouteValidationError
+
+
+@pytest.mark.parametrize(
+    ["override_operation_id", "expected_operation_id"],
+    [(None, "get__foo"), ("getFoo", "getFoo")],
+)
+def test_operation_id_override(override_operation_id, expected_operation_id):
+    api = SpecTree("flask")
+    app = Flask(__name__)
+
+    @app.route("/foo")
+    @api.validate(operation_id=override_operation_id)
+    def foo():
+        pass
+
+    api.register(app)
+
+    with app.app_context():
+        operation_id = api.spec["paths"]["/foo"]["get"]["operationId"]
+        assert operation_id == expected_operation_id


### PR DESCRIPTION
The [operationId](https://swagger.io/docs/specification/paths-and-operations/) path parameter in OpenAPI is used by the most popular code generators to generate names for functions and methods. In the current, auto-generated OpenAPI spec output the operationId parameter’s value is generated from the path of the endpoint. E.g. get_/resource/{resource_id}, which leads to difficult-to-read names in code.

This change allows setting custom operationId through the `operation_id` parameter to the `validate` decorator.