### PR TITLE
add test for top-level json list, use syrupy snapshot

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest syrupy
       - name: Test
         run: make test

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
             "isort~=5.10",
             "autoflake>=1.4,<3.0",
             "mypy>=0.971",
+            "syrupy>=4.0.0",
         ],
     },
 )

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -1,0 +1,805 @@
+{
+  "components": {
+    "schemas": {
+      "Cookies.7068f62": {
+        "properties": {
+          "pub": {
+            "title": "Pub",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pub"
+        ],
+        "title": "Cookies",
+        "type": "object"
+      },
+      "FormFileUpload.7068f62": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "FormFileUpload",
+        "type": "object"
+      },
+      "Headers.7068f62": {
+        "properties": {
+          "lang": {
+            "$ref": "#/components/schemas/Headers.7068f62.Language"
+          }
+        },
+        "required": [
+          "lang"
+        ],
+        "title": "Headers",
+        "type": "object"
+      },
+      "Headers.7068f62.Language": {
+        "description": "An enumeration.",
+        "enum": [
+          "en-US",
+          "zh-CN"
+        ],
+        "title": "Language",
+        "type": "string"
+      },
+      "JSON.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "ListJSON.7068f62": {
+        "items": {
+          "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
+        },
+        "title": "ListJSON",
+        "type": "array"
+      },
+      "ListJSON.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "Query.7068f62": {
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/Query.7068f62.Order"
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "title": "Query",
+        "type": "object"
+      },
+      "Query.7068f62.Order": {
+        "description": "An enumeration.",
+        "enum": [
+          0,
+          1
+        ],
+        "title": "Order",
+        "type": "integer"
+      },
+      "Resp.7068f62": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "score": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Score",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "Resp",
+        "type": "object"
+      },
+      "StrDict.7068f62": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "StrDict",
+        "type": "object"
+      },
+      "ValidationError.6a07bef": {
+        "description": "Model of a validation error response.",
+        "items": {
+          "$ref": "#/components/schemas/ValidationError.6a07bef.ValidationErrorElement"
+        },
+        "title": "ValidationError",
+        "type": "array"
+      },
+      "ValidationError.6a07bef.ValidationErrorElement": {
+        "description": "Model of a validation error response element.",
+        "properties": {
+          "ctx": {
+            "title": "Error context",
+            "type": "object"
+          },
+          "loc": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing field name",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Error message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorElement",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Service API Document",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/file_upload": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_file_upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormFileUpload.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "on_post <POST>",
+        "tags": []
+      }
+    },
+    "/api/list_json": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_list_json",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListJSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "on_post <POST>",
+        "tags": []
+      }
+    },
+    "/api/no_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_no_response",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "on_post <POST>",
+        "tags": []
+      }
+    },
+    "/api/user/{name}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user/{name}/address/{address_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}_address_{address_id}",
+        "parameters": [
+          {
+            "description": "The name that uniquely identifies the user.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "on_get <GET>",
+        "tags": []
+      }
+    },
+    "/api/user_annotated/{name}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_model/{name}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_skip/{name}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "description",
+        "operationId": "get__ping",
+        "parameters": [
+          {
+            "description": "",
+            "in": "header",
+            "name": "lang",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Headers.7068f62.Language"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "summary",
+        "tags": [
+          "test",
+          "health"
+        ]
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "test"
+    },
+    {
+      "name": "health"
+    },
+    {
+      "description": "🐱",
+      "externalDocs": {
+        "description": "",
+        "url": "https://pypi.org"
+      },
+      "name": "API"
+    }
+  ]
+}

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -1,0 +1,693 @@
+{
+  "components": {
+    "schemas": {
+      "Cookies.7068f62": {
+        "properties": {
+          "pub": {
+            "title": "Pub",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pub"
+        ],
+        "title": "Cookies",
+        "type": "object"
+      },
+      "Form.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "Form",
+        "type": "object"
+      },
+      "FormFileUpload.7068f62": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "FormFileUpload",
+        "type": "object"
+      },
+      "Headers.7068f62": {
+        "properties": {
+          "lang": {
+            "$ref": "#/components/schemas/Headers.7068f62.Language"
+          }
+        },
+        "required": [
+          "lang"
+        ],
+        "title": "Headers",
+        "type": "object"
+      },
+      "Headers.7068f62.Language": {
+        "description": "An enumeration.",
+        "enum": [
+          "en-US",
+          "zh-CN"
+        ],
+        "title": "Language",
+        "type": "string"
+      },
+      "JSON.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "ListJSON.7068f62": {
+        "items": {
+          "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
+        },
+        "title": "ListJSON",
+        "type": "array"
+      },
+      "ListJSON.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "Query.7068f62": {
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/Query.7068f62.Order"
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "title": "Query",
+        "type": "object"
+      },
+      "Query.7068f62.Order": {
+        "description": "An enumeration.",
+        "enum": [
+          0,
+          1
+        ],
+        "title": "Order",
+        "type": "integer"
+      },
+      "Resp.7068f62": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "score": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Score",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "Resp",
+        "type": "object"
+      },
+      "StrDict.7068f62": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "StrDict",
+        "type": "object"
+      },
+      "ValidationError.6a07bef": {
+        "description": "Model of a validation error response.",
+        "items": {
+          "$ref": "#/components/schemas/ValidationError.6a07bef.ValidationErrorElement"
+        },
+        "title": "ValidationError",
+        "type": "array"
+      },
+      "ValidationError.6a07bef.ValidationErrorElement": {
+        "description": "Model of a validation error response element.",
+        "properties": {
+          "ctx": {
+            "title": "Error context",
+            "type": "object"
+          },
+          "loc": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing field name",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Error message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorElement",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Service API Document",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/file_upload": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_file_upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormFileUpload.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "file_upload <POST>",
+        "tags": []
+      }
+    },
+    "/api/list_json": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_list_json",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListJSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "json_list <POST>",
+        "tags": []
+      }
+    },
+    "/api/no_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "no_response <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/user/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user/{name}/address/{address_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}_address_{address_id}",
+        "parameters": [
+          {
+            "description": "The name that uniquely identifies the user.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "user_address <GET>",
+        "tags": []
+      }
+    },
+    "/api/user_annotated/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_annotated <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_model/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_model <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_skip/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_skip_validation <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "description",
+        "operationId": "get__ping",
+        "parameters": [
+          {
+            "description": "",
+            "in": "header",
+            "name": "lang",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Headers.7068f62.Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "summary",
+        "tags": [
+          "test",
+          "health"
+        ]
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "test"
+    },
+    {
+      "name": "health"
+    },
+    {
+      "description": "🐱",
+      "externalDocs": {
+        "description": "",
+        "url": "https://pypi.org"
+      },
+      "name": "API"
+    }
+  ]
+}

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -1,0 +1,693 @@
+{
+  "components": {
+    "schemas": {
+      "Cookies.7068f62": {
+        "properties": {
+          "pub": {
+            "title": "Pub",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pub"
+        ],
+        "title": "Cookies",
+        "type": "object"
+      },
+      "Form.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "Form",
+        "type": "object"
+      },
+      "FormFileUpload.7068f62": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "FormFileUpload",
+        "type": "object"
+      },
+      "Headers.7068f62": {
+        "properties": {
+          "lang": {
+            "$ref": "#/components/schemas/Headers.7068f62.Language"
+          }
+        },
+        "required": [
+          "lang"
+        ],
+        "title": "Headers",
+        "type": "object"
+      },
+      "Headers.7068f62.Language": {
+        "description": "An enumeration.",
+        "enum": [
+          "en-US",
+          "zh-CN"
+        ],
+        "title": "Language",
+        "type": "string"
+      },
+      "JSON.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "ListJSON.7068f62": {
+        "items": {
+          "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
+        },
+        "title": "ListJSON",
+        "type": "array"
+      },
+      "ListJSON.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "Query.7068f62": {
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/Query.7068f62.Order"
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "title": "Query",
+        "type": "object"
+      },
+      "Query.7068f62.Order": {
+        "description": "An enumeration.",
+        "enum": [
+          0,
+          1
+        ],
+        "title": "Order",
+        "type": "integer"
+      },
+      "Resp.7068f62": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "score": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Score",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "Resp",
+        "type": "object"
+      },
+      "StrDict.7068f62": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "StrDict",
+        "type": "object"
+      },
+      "ValidationError.6a07bef": {
+        "description": "Model of a validation error response.",
+        "items": {
+          "$ref": "#/components/schemas/ValidationError.6a07bef.ValidationErrorElement"
+        },
+        "title": "ValidationError",
+        "type": "array"
+      },
+      "ValidationError.6a07bef.ValidationErrorElement": {
+        "description": "Model of a validation error response element.",
+        "properties": {
+          "ctx": {
+            "title": "Error context",
+            "type": "object"
+          },
+          "loc": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing field name",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Error message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorElement",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Service API Document",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/file_upload": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_file_upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormFileUpload.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "file_upload <POST>",
+        "tags": []
+      }
+    },
+    "/api/list_json": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_list_json",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListJSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "list_json <POST>",
+        "tags": []
+      }
+    },
+    "/api/no_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "no_response <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/user/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user/{name}/address/{address_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}_address_{address_id}",
+        "parameters": [
+          {
+            "description": "The name that uniquely identifies the user.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "user_address <GET>",
+        "tags": []
+      }
+    },
+    "/api/user_annotated/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_annotated <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_model/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_model <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_skip/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_skip_validation <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "description",
+        "operationId": "get__ping",
+        "parameters": [
+          {
+            "description": "",
+            "in": "header",
+            "name": "lang",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Headers.7068f62.Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "summary",
+        "tags": [
+          "test",
+          "health"
+        ]
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "test"
+    },
+    {
+      "name": "health"
+    },
+    {
+      "description": "🐱",
+      "externalDocs": {
+        "description": "",
+        "url": "https://pypi.org"
+      },
+      "name": "API"
+    }
+  ]
+}

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -1,0 +1,708 @@
+{
+  "components": {
+    "schemas": {
+      "Cookies.7068f62": {
+        "properties": {
+          "pub": {
+            "title": "Pub",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pub"
+        ],
+        "title": "Cookies",
+        "type": "object"
+      },
+      "Form.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "Form",
+        "type": "object"
+      },
+      "FormFileUpload.7068f62": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "FormFileUpload",
+        "type": "object"
+      },
+      "Headers.7068f62": {
+        "properties": {
+          "lang": {
+            "$ref": "#/components/schemas/Headers.7068f62.Language"
+          }
+        },
+        "required": [
+          "lang"
+        ],
+        "title": "Headers",
+        "type": "object"
+      },
+      "Headers.7068f62.Language": {
+        "description": "An enumeration.",
+        "enum": [
+          "en-US",
+          "zh-CN"
+        ],
+        "title": "Language",
+        "type": "string"
+      },
+      "JSON.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "ListJSON.7068f62": {
+        "items": {
+          "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
+        },
+        "title": "ListJSON",
+        "type": "array"
+      },
+      "ListJSON.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "Query.7068f62": {
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/Query.7068f62.Order"
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "title": "Query",
+        "type": "object"
+      },
+      "Query.7068f62.Order": {
+        "description": "An enumeration.",
+        "enum": [
+          0,
+          1
+        ],
+        "title": "Order",
+        "type": "integer"
+      },
+      "Resp.7068f62": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "score": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Score",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "Resp",
+        "type": "object"
+      },
+      "StrDict.7068f62": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "StrDict",
+        "type": "object"
+      },
+      "ValidationError.6a07bef": {
+        "description": "Model of a validation error response.",
+        "items": {
+          "$ref": "#/components/schemas/ValidationError.6a07bef.ValidationErrorElement"
+        },
+        "title": "ValidationError",
+        "type": "array"
+      },
+      "ValidationError.6a07bef.ValidationErrorElement": {
+        "description": "Model of a validation error response element.",
+        "properties": {
+          "ctx": {
+            "title": "Error context",
+            "type": "object"
+          },
+          "loc": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing field name",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Error message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorElement",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Service API Document",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/file_upload": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_file_upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormFileUpload.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "post <POST>",
+        "tags": []
+      }
+    },
+    "/api/list_json": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_list_json",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListJSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "post <POST>",
+        "tags": []
+      }
+    },
+    "/api/no_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_no_response",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "post <POST>",
+        "tags": []
+      }
+    },
+    "/api/user/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user/{name}/address/{address_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}_address_{address_id}",
+        "parameters": [
+          {
+            "description": "The name that uniquely identifies the user.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      }
+    },
+    "/api/user_annotated/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_model/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_skip/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Form.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "post <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "description",
+        "operationId": "get__ping",
+        "parameters": [
+          {
+            "description": "",
+            "in": "header",
+            "name": "lang",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Headers.7068f62.Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "summary",
+        "tags": [
+          "test",
+          "health"
+        ]
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "test"
+    },
+    {
+      "name": "health"
+    },
+    {
+      "description": "🐱",
+      "externalDocs": {
+        "description": "",
+        "url": "https://pypi.org"
+      },
+      "name": "API"
+    }
+  ]
+}

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -1,0 +1,693 @@
+{
+  "components": {
+    "schemas": {
+      "Cookies.7068f62": {
+        "properties": {
+          "pub": {
+            "title": "Pub",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pub"
+        ],
+        "title": "Cookies",
+        "type": "object"
+      },
+      "FormFileUpload.7068f62": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "FormFileUpload",
+        "type": "object"
+      },
+      "Headers.7068f62": {
+        "properties": {
+          "lang": {
+            "$ref": "#/components/schemas/Headers.7068f62.Language"
+          }
+        },
+        "required": [
+          "lang"
+        ],
+        "title": "Headers",
+        "type": "object"
+      },
+      "Headers.7068f62.Language": {
+        "description": "An enumeration.",
+        "enum": [
+          "en-US",
+          "zh-CN"
+        ],
+        "title": "Language",
+        "type": "string"
+      },
+      "JSON.7068f62": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "ListJSON.7068f62": {
+        "items": {
+          "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
+        },
+        "title": "ListJSON",
+        "type": "array"
+      },
+      "ListJSON.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
+      "Query.7068f62": {
+        "properties": {
+          "order": {
+            "$ref": "#/components/schemas/Query.7068f62.Order"
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "title": "Query",
+        "type": "object"
+      },
+      "Query.7068f62.Order": {
+        "description": "An enumeration.",
+        "enum": [
+          0,
+          1
+        ],
+        "title": "Order",
+        "type": "integer"
+      },
+      "Resp.7068f62": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "score": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Score",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "Resp",
+        "type": "object"
+      },
+      "StrDict.7068f62": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "StrDict",
+        "type": "object"
+      },
+      "ValidationError.6a07bef": {
+        "description": "Model of a validation error response.",
+        "items": {
+          "$ref": "#/components/schemas/ValidationError.6a07bef.ValidationErrorElement"
+        },
+        "title": "ValidationError",
+        "type": "array"
+      },
+      "ValidationError.6a07bef.ValidationErrorElement": {
+        "description": "Model of a validation error response element.",
+        "properties": {
+          "ctx": {
+            "title": "Error context",
+            "type": "object"
+          },
+          "loc": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing field name",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Error message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorElement",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Service API Document",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/file_upload": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_file_upload",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/FormFileUpload.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "file_upload <POST>",
+        "tags": []
+      }
+    },
+    "/api/list_json": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_list_json",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListJSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {},
+        "summary": "list_json <POST>",
+        "tags": []
+      }
+    },
+    "/api/no_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "no_response <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_no_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StrDict.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/user/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user/{name}/address/{address_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_user_{name}_address_{address_id}",
+        "parameters": [
+          {
+            "description": "The name that uniquely identifies the user.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "path",
+            "name": "address_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "user_address <GET>",
+        "tags": []
+      }
+    },
+    "/api/user_annotated/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_annotated_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_annotated <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_model/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_model_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_model <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/api/user_skip/{name}": {
+      "post": {
+        "description": "",
+        "operationId": "post__api_user_skip_{name}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "order",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Query.7068f62.Order"
+            }
+          },
+          {
+            "description": "",
+            "in": "cookie",
+            "name": "pub",
+            "required": true,
+            "schema": {
+              "title": "Pub",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "user_score_skip <POST>",
+        "tags": [
+          "API",
+          "test"
+        ]
+      }
+    },
+    "/ping": {
+      "get": {
+        "description": "description",
+        "operationId": "get__ping",
+        "parameters": [
+          {
+            "description": "",
+            "in": "header",
+            "name": "lang",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Headers.7068f62.Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StrDict.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "summary",
+        "tags": [
+          "test",
+          "health"
+        ]
+      }
+    }
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "test"
+    },
+    {
+      "name": "health"
+    },
+    {
+      "description": "🐱",
+      "externalDocs": {
+        "description": "",
+        "url": "https://pypi.org"
+      },
+      "name": "API"
+    }
+  ]
+}

--- a/tests/common.py
+++ b/tests/common.py
@@ -34,6 +34,10 @@ class JSON(BaseModel):
     limit: int
 
 
+class ListJSON(BaseModel):
+    __root__: List[JSON]
+
+
 class StrDict(BaseModel):
     __root__: Dict[str, str]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from syrupy.extensions.json import JSONSnapshotExtension
+
+
+@pytest.fixture
+def snapshot_json(snapshot):
+    return snapshot.use_extension(JSONSnapshotExtension)

--- a/tests/flask_imports/__init__.py
+++ b/tests/flask_imports/__init__.py
@@ -1,5 +1,6 @@
 from .dry_plugin_flask import (
     test_flask_doc,
+    test_flask_list_json_request,
     test_flask_no_response,
     test_flask_return_model,
     test_flask_skip_validation,
@@ -16,4 +17,5 @@ __all__ = [
     "test_flask_validate_post_data",
     "test_flask_no_response",
     "test_flask_upload_file",
+    "test_flask_list_json_request",
 ]

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -156,6 +156,11 @@ def test_flask_no_response(client):
     assert resp.status_code == 200, resp.data
 
 
+def test_flask_list_json_request(client):
+    resp = client.post("/api/list_json", json=[{"name": "foo", "limit": 1}])
+    assert resp.status_code == 200, resp.data
+
+
 def test_flask_upload_file(client):
     file_content = "abcdef"
     data = {"file": (io.BytesIO(file_content.encode("utf-8")), "test.txt")}

--- a/tests/quart_imports/dry_plugin_quart.py
+++ b/tests/quart_imports/dry_plugin_quart.py
@@ -155,3 +155,10 @@ def test_quart_no_response(client):
         client.post("/api/no_response", json={"name": "foo", "limit": 1})
     )
     assert resp.status_code == 200
+
+
+def test_quart_list_json_request(client):
+    resp = asyncio.run(
+        client.post("/api/list_json", json=[{"name": "foo", "limit": 1}])
+    )
+    assert resp.status_code == 200

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -10,6 +10,7 @@ from .common import (
     Cookies,
     FormFileUpload,
     Headers,
+    ListJSON,
     Query,
     Resp,
     StrDict,
@@ -185,6 +186,16 @@ class FileUploadView:
         resp.media = {"file": file_content.decode("utf-8")}
 
 
+class ListJsonView:
+    name = "json list request view"
+
+    @api.validate(
+        json=ListJSON,
+    )
+    def on_post(self, req, resp, json: ListJSON):
+        pass
+
+
 app = App()
 app.add_route("/ping", Ping())
 app.add_route("/api/user/{name}", UserScore())
@@ -194,6 +205,7 @@ app.add_route("/api/user_skip/{name}", UserScoreSkip())
 app.add_route("/api/user_model/{name}", UserScoreModel())
 app.add_route("/api/no_response", NoResponseView())
 app.add_route("/api/file_upload", FileUploadView())
+app.add_route("/api/list_json", ListJsonView())
 api.register(app)
 
 
@@ -282,6 +294,15 @@ def test_falcon_no_response(client):
     resp = client.simulate_request(
         "GET",
         "/api/no_response",
+    )
+    assert resp.status_code == 200
+
+
+def test_falcon_list_json_request_sync(client):
+    resp = client.simulate_request(
+        "POST",
+        "/api/list_json",
+        json=[dict(name="foo", limit=1)],
     )
     assert resp.status_code == 200
 

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -11,6 +11,7 @@ from .common import (
     Cookies,
     FormFileUpload,
     Headers,
+    ListJSON,
     Query,
     Resp,
     StrDict,
@@ -110,6 +111,16 @@ class NoResponseView:
         pass
 
 
+class ListJsonView:
+    name = "json list request view"
+
+    @api.validate(
+        json=ListJSON,
+    )
+    async def on_post(self, req, resp, json: ListJSON):
+        pass
+
+
 class FileUploadView:
     name = "file upload view"
 
@@ -128,6 +139,7 @@ app.add_route("/api/user/{name}", UserScore())
 app.add_route("/api/user_annotated/{name}", UserScoreAnnotated())
 app.add_route("/api/no_response", NoResponseView())
 app.add_route("/api/file_upload", FileUploadView())
+app.add_route("/api/list_json", ListJsonView())
 api.register(app)
 
 
@@ -147,6 +159,15 @@ def test_falcon_no_response(client):
         "POST",
         "/api/no_response",
         json=dict(name="foo", limit=1),
+    )
+    assert resp.status_code == 200
+
+
+def test_falcon_list_json_request_async(client):
+    resp = client.simulate_request(
+        "POST",
+        "/api/list_json",
+        json=[dict(name="foo", limit=1)],
     )
     assert resp.status_code == 200
 

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -12,6 +12,7 @@ from .common import (
     Form,
     FormFileUpload,
     Headers,
+    ListJSON,
     Order,
     Query,
     Resp,
@@ -156,6 +157,14 @@ def user_address(name, address_id):
     json=StrDict,
 )
 def no_response():
+    return {}
+
+
+@app.route("/api/list_json", methods=["POST"])
+@api.validate(
+    json=ListJSON,
+)
+def json_list():
     return {}
 
 

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -11,6 +11,7 @@ from .common import (
     Form,
     FormFileUpload,
     Headers,
+    ListJSON,
     Order,
     Query,
     Resp,
@@ -145,6 +146,14 @@ def user_address(name, address_id):
     json=StrDict,
 )
 def no_response():
+    return {}
+
+
+@app.route("/api/list_json", methods=["POST"])
+@api.validate(
+    json=ListJSON,
+)
+def list_json():
     return {}
 
 

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -12,6 +12,7 @@ from .common import (
     Form,
     FormFileUpload,
     Headers,
+    ListJSON,
     Order,
     Query,
     Resp,
@@ -159,6 +160,14 @@ class NoResponseView(MethodView):
         return {}
 
 
+class ListJsonView(MethodView):
+    @api.validate(
+        json=ListJSON,
+    )
+    def post(self):
+        return {}
+
+
 app.add_url_rule("/ping", view_func=Ping.as_view("ping"))
 app.add_url_rule("/api/user/<name>", view_func=User.as_view("user"), methods=["POST"])
 app.add_url_rule(
@@ -188,6 +197,10 @@ app.add_url_rule(
 app.add_url_rule(
     "/api/file_upload",
     view_func=FileUploadView.as_view("file_upload_view"),
+)
+app.add_url_rule(
+    "/api/list_json",
+    view_func=ListJsonView.as_view("list_json_view"),
 )
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_plugin_quart.py
+++ b/tests/test_plugin_quart.py
@@ -10,6 +10,7 @@ from .common import (
     SECURITY_SCHEMAS,
     Cookies,
     Headers,
+    ListJSON,
     Order,
     Query,
     Resp,
@@ -138,6 +139,14 @@ async def user_address(name, address_id):
     json=JSON,
 )
 async def no_response():
+    return {}
+
+
+@app.route("/api/list_json", methods=["POST"])
+@api.validate(
+    json=ListJSON,
+)
+async def list_json():
     return {}
 
 

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -17,6 +17,7 @@ from .common import (
     Cookies,
     FormFileUpload,
     Headers,
+    ListJSON,
     Order,
     Query,
     Resp,
@@ -134,6 +135,13 @@ async def no_response(request):
     return JSONResponse({})
 
 
+@api.validate(
+    json=ListJSON,
+)
+async def list_json(request):
+    return JSONResponse({})
+
+
 app = Starlette(
     routes=[
         Route("/ping", Ping),
@@ -166,6 +174,7 @@ app = Starlette(
                 ),
                 Route("/no_response", no_response, methods=["POST", "GET"]),
                 Route("/file_upload", file_upload, methods=["POST"]),
+                Route("/list_json", list_json, methods=["POST"]),
             ],
         ),
         Mount("/static", app=StaticFiles(directory="docs"), name="static"),
@@ -356,6 +365,11 @@ def test_starlette_no_response(client):
     assert resp.status_code == 200, resp.text
 
     resp = client.post("/api/no_response", json={"name": "starlette", "limit": 1})
+    assert resp.status_code == 200, resp.text
+
+
+def test_json_list_request(client):
+    resp = client.post("/api/list_json", json=[{"name": "starlette", "limit": 1}])
     assert resp.status_code == 200, resp.text
 
 


### PR DESCRIPTION
- fix for https://github.com/0b01001001/spectree/discussions/292
- adding support for `List[Model]` does not look straightforward, so defining `ListModel` is needed for now 
- also the specs is now compared as a whole snapshot via Syrupy instead of manual subset. I had to touch that test, as the list of endpoints there has changed. This way it feels more convenient than updating it manually every time.