### PR TITLE
Use json encoders from model

### DIFF
--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -229,7 +229,7 @@ class FalconPlugin(BasePlugin):
         if resp and resp.has_model():
             model = resp.find_model(_resp.status[:3])
             if model and isinstance(_resp.media, model):
-                _resp.media = _resp.media.dict()
+                _resp.media = _resp.media.json().encode('UTF-8')
                 skip_validation = True
 
             if model and not skip_validation:
@@ -325,7 +325,7 @@ class FalconAsgiPlugin(FalconPlugin):
         if resp and resp.has_model():
             model = resp.find_model(_resp.status[:3])
             if model and isinstance(_resp.media, model):
-                _resp.media = _resp.media.dict()
+                _resp.media = _resp.media.json().encode('UTF-8')
                 skip_validation = True
 
             model = resp.find_model(_resp.status[:3])


### PR DESCRIPTION
Suppose you have an example

```python
from datetime import datetime

import falcon
from wsgiref import simple_server
from pydantic import BaseModel, Field, constr
from spectree import SpecTree, Response


class Message(BaseModel):
    text: str
    when: datetime

    class Config:
        json_encoders = {
            datetime: lambda v: v.timestamp(),
        }


spec = SpecTree("falcon")


class UserProfile:
    @spec.validate(
        resp=Response(HTTP_200=Message, HTTP_403=None), tags=["api"]
    )
    def on_post(self, req, resp):
        resp.media = Message(text='it works', when=datetime.now())


if __name__ == "__main__":
    app = falcon.App()
    app.add_route("/api/user", UserProfile())
    spec.register(app)

    httpd = simple_server.make_server("localhost", 8000, app)
    httpd.serve_forever()
```

When accessing the endpoint, without the fix from the PR you will get an error: `TypeError: Object of type datetime is not JSON serializable`

We need to call `.json()` from pydantic to make sure that all the encodign is done according to the definition.

If you think that the approach with calling `.json().encode('UTF-8')` is right, ill happily add tests for this case