### PR TITLE
Allow overriding operation_id for each path on a single view function

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    Union,
     get_type_hints,
 )
 
@@ -132,7 +133,7 @@ class SpecTree:
         validation_error_status: int = 0,
         path_parameter_descriptions: Optional[Mapping[str, str]] = None,
         skip_validation: bool = False,
-        operation_id: Optional[str] = None,
+        operation_id: Optional[Union[str, Mapping[str, str]]] = None,
     ) -> Callable:
         """
         - validate query, json, headers in request
@@ -288,6 +289,8 @@ class SpecTree:
                         )
 
                 operation_id = getattr(func, "operation_id", None)
+                if isinstance(operation_id, dict):
+                    operation_id = operation_id.get(path)
                 if not operation_id:
                     operation_id = f"{method.lower()}_{path.replace('/', '_')}"
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -288,11 +288,7 @@ class SpecTree:
                             tag.dict() if isinstance(tag, Tag) else {"name": tag}
                         )
 
-                operation_id = getattr(func, "operation_id", None)
-                if isinstance(operation_id, dict):
-                    operation_id = operation_id.get(path)
-                if not operation_id:
-                    operation_id = f"{method.lower()}_{path.replace('/', '_')}"
+                operation_id = self._get_func_operation_id(func, path, method)
 
                 routes[path][method.lower()] = {
                     "summary": summary or f"{name} <{method}>",
@@ -338,6 +334,19 @@ class SpecTree:
 
         spec["security"] = get_security(self.config.security)
         return spec
+
+    def _get_func_operation_id(
+        self,
+        func: Callable,
+        path: str,
+        method: str,
+    ) -> str:
+        operation_id = getattr(func, "operation_id", None)
+        if isinstance(operation_id, dict):
+            operation_id = operation_id.get(path)
+        if not operation_id:
+            operation_id = f"{method.lower()}_{path.replace('/', '_')}"
+        return operation_id
 
     def _get_model_definitions(self) -> Dict[str, Any]:
         """

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -224,6 +224,11 @@ def test_global_model_for_validation_errors_specified():
     [
         pytest.param({"/foo": "get__foo"}, None, id="no-override"),
         pytest.param({"/foo": "getFoo"}, "getFoo", id="single-path-override"),
+        pytest.param(
+            {"/foo": "getFoo", "/bar": "getBar", "/baz": "get__baz"},
+            {"/foo": "getFoo", "/bar": "getBar"},
+            id="multi-path-override",
+        ),
     ],
 )
 def test_operation_id_override(


### PR DESCRIPTION
We encountered this limitation on Flask. I hope you find it useful.