### PR TITLE
Refactor the get_model_key util function

### DIFF
--- a/spectree/_types.py
+++ b/spectree/_types.py
@@ -1,10 +1,22 @@
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+)
 
 from pydantic import BaseModel
 from typing_extensions import Protocol
 
 ModelType = Type[BaseModel]
 OptionalModelType = Optional[ModelType]
+NamingStrategy = Callable[[ModelType], str]
 
 
 class MultiDict(Protocol):

--- a/spectree/response.py
+++ b/spectree/response.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from pydantic import BaseModel
 
-from ._types import ModelType, OptionalModelType
+from ._types import ModelType, NamingStrategy, OptionalModelType
 from .utils import gen_list_model, get_model_key, parse_code
 
 
@@ -121,7 +121,9 @@ class Response:
         """
         return self.code_models.values()
 
-    def generate_spec(self) -> Dict[str, Any]:
+    def generate_spec(
+        self, naming_strategy: NamingStrategy = get_model_key
+    ) -> Dict[str, Any]:
         """
         generate the spec for responses
 
@@ -134,7 +136,7 @@ class Response:
             }
 
         for code, model in self.code_models.items():
-            model_name = get_model_key(model=model)
+            model_name = naming_strategy(model)
             responses[parse_code(code)] = {
                 "description": self.get_code_description(code),
                 "content": {


### PR DESCRIPTION
Following the discussion in https://github.com/0b01001001/spectree/issues/300 this refactor moves the function `get_model_key()` from `utils.py` to `BasePlugin` as a staticmethod.

This will allow custom plugin implementations to override the way the model key is generated as described by @kemingy [here](https://github.com/0b01001001/spectree/issues/300#issuecomment-1515620897).

The following example describes how to create a custom flask plugin that does not append the module hash to the model name:
```python
class YourFlaskPlugin(FlaskPlugin):
    def get_model_key(model: ModelType) -> str:
        return f"{model.__name__}"

spec = SpecTree(backend=YourFlaskPlugin)
```

EDIT:


> After lots of attempts to refactor through the `staticmethod` on the Base Plugin and continuously running into cyclical imports I decided to change course in the implementation. I decided to go with the good old Strategy pattern. Here's the new usage guide:
> 
> ```python
> spec = SpecTree(naming_strategy=lambda model: f"{model.__name__}")
> ```