### PR TITLE
Add Support for customizing how nested names are generated

### DIFF
--- a/spectree/_types.py
+++ b/spectree/_types.py
@@ -17,6 +17,7 @@ from typing_extensions import Protocol
 ModelType = Type[BaseModel]
 OptionalModelType = Optional[ModelType]
 NamingStrategy = Callable[[ModelType], str]
+NestedNamingStrategy = Callable[[str, str], str]
 
 
 class MultiDict(Protocol):


### PR DESCRIPTION
In the normal behavior the nested models are suffixed with the parent model name. This merge allows to override that behavior in the `Spectree` class. For example:

```python
spec = SpecTree(
    nested_naming_strategy=lambda _, child: child 
)
```