### PR TITLE
Add publish_apidoc flag to SpecTree constructor

### DIFF
--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -70,12 +70,11 @@ class FalconPlugin(BasePlugin):
         self.INT_ARGS_NAMES = ("num_digits", "min", "max")
 
     def register_route(self, app: Any):
-        self.app = app
-        self.app.add_route(
+        app.add_route(
             self.config.spec_url, self.OPEN_API_ROUTE_CLASS(self.spectree.spec)
         )
         for ui in self.config.page_templates:
-            self.app.add_route(
+            app.add_route(
                 f"/{self.config.path}/{ui}",
                 self.DOC_PAGE_ROUTE_CLASS(
                     self.config.page_templates[ui],
@@ -95,7 +94,7 @@ class FalconPlugin(BasePlugin):
             for child in node.children:
                 find_node(child)
 
-        for route in self.app._router._roots:
+        for route in self.spectree.app._router._roots:
             find_node(route)
 
         return routes

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -36,15 +36,13 @@ class StarlettePlugin(BasePlugin):
         self.conv2type = {conv: typ for typ, conv in CONVERTOR_TYPES.items()}
 
     def register_route(self, app):
-        self.app = app
-
-        self.app.add_route(
+        app.add_route(
             self.config.spec_url,
             lambda request: JSONResponse(self.spectree.spec),
         )
 
         for ui in self.config.page_templates:
-            self.app.add_route(
+            app.add_route(
                 f"/{self.config.path}/{ui}",
                 lambda request, ui=ui: HTMLResponse(
                     self.config.page_templates[ui].format(
@@ -177,7 +175,7 @@ class StarlettePlugin(BasePlugin):
                 else:
                     parse_route(route, prefix=f"{prefix}{route.path}")
 
-        parse_route(self.app)
+        parse_route(self.spectree.app)
         return routes
 
     def bypass(self, func, method):

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -99,8 +99,6 @@ class SpecTree:
         self.app = app
         if self.publish_apidoc:
             self.backend.register_route(self.app)
-        else:
-            self.backend.app = self.app
 
     @property
     def spec(self):

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -67,6 +67,7 @@ class SpecTree:
         validation_error_model: Optional[ModelType] = None,
         naming_strategy: NamingStrategy = get_model_key,
         nested_naming_strategy: NestedNamingStrategy = get_nested_key,
+        publish_apidoc: bool = True,
         **kwargs: Any,
     ):
         self.naming_strategy = naming_strategy
@@ -77,6 +78,7 @@ class SpecTree:
         self.validation_error_model = validation_error_model or ValidationError
         self.config: Configuration = Configuration.parse_obj(kwargs)
         self.backend_name = backend_name
+        self.publish_apidoc = publish_apidoc
         if backend:
             self.backend = backend(self)
         else:
@@ -95,7 +97,10 @@ class SpecTree:
         init step.
         """
         self.app = app
-        self.backend.register_route(self.app)
+        if self.publish_apidoc:
+            self.backend.register_route(self.app)
+        else:
+            self.backend.app = self.app
 
     @property
     def spec(self):


### PR DESCRIPTION
The `publish_apidoc` flag is added to the `SpecTree` constructor to allow users to disable publishing of the API documentation. If the flag is set to `False`, the `register_route` method will not be called, and the `backend.app` attribute will be set to the `app` attribute.

As discussed in https://github.com/0b01001001/spectree/issues/310