### PR TITLE
Extract the logic for getting the operation_id to a plugin method

### DIFF
--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -109,3 +109,16 @@ class BasePlugin(Generic[BackendRoute]):
         get the endpoint function from routes
         """
         raise NotImplementedError
+
+    def get_func_operation_id(self, func: Callable, path: str, method: str):
+        """
+        :param func: route function (endpoint)
+        :param method: URI path for this route function
+        :param method: HTTP method for this route function
+
+        get the operation_id value for the endpoint
+        """
+        operation_id = getattr(func, "operation_id", None)
+        if not operation_id:
+            operation_id = f"{method.lower()}_{path.replace('/', '_')}"
+        return operation_id

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -300,13 +300,11 @@ class SpecTree:
                             tag.dict() if isinstance(tag, Tag) else {"name": tag}
                         )
 
-                operation_id = getattr(func, "operation_id", None)
-                if not operation_id:
-                    operation_id = f"{method.lower()}_{path.replace('/', '_')}"
-
                 routes[path][method.lower()] = {
                     "summary": summary or f"{name} <{method}>",
-                    "operationId": operation_id,
+                    "operationId": self.backend.get_func_operation_id(
+                        func, path, method
+                    ),
                     "description": desc or "",
                     "tags": [str(x) for x in getattr(func, "tags", ())],
                     "parameters": parse_params(func, parameters[:], self.models),


### PR DESCRIPTION
This is a continuation of the abandoned [#297 Allow overriding operation_id for each path on a single view function](https://github.com/0b01001001/spectree/pull/297) pull request.

I am a colleague of the author of that PR, and at our company we need to be able to override the implementation for the `operation_id` fields. Extracting that functionality in a separate method like this will enable us to do it.

I followed [this suggestion](https://github.com/0b01001001/spectree/pull/297#discussion_r1156158690) from @kemingy for this PR.