### PR TITLE
Upgrade to Pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Try it with `http post :8000/api/user name=alice age=18`. (if you are using `htt
 
 ```py
 from flask import Flask, request, jsonify
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, ConfigDict, Field, constr
 from spectree import SpecTree, Response
 
 
@@ -293,15 +293,15 @@ class Profile(BaseModel):
     name: constr(min_length=2, max_length=40)  # constrained str
     age: int = Field(..., gt=0, lt=150, description="user age(Human)")
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra = {
             # provide an example
             "example": {
                 "name": "very_important_user",
                 "age": 42,
             }
         }
-
+    )
 
 class Message(BaseModel):
     text: str
@@ -353,7 +353,7 @@ def user_profile(json: Profile):
 
 ```py
 from quart import Quart, jsonify, request
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, ConfigDict, Field, constr
 
 from spectree import SpecTree, Response
 
@@ -362,14 +362,15 @@ class Profile(BaseModel):
     name: constr(min_length=2, max_length=40)  # constrained str
     age: int = Field(..., gt=0, lt=150, description="user age")
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra = {
             # provide an example
             "example": {
                 "name": "very_important_user",
                 "age": 42,
             }
         }
+    )
 
 
 class Message(BaseModel):

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -1,11 +1,11 @@
 from enum import Enum
 from random import random
 
+from common import File, FileResp, Query
 from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-from examples.common import File, FileResp, Query
 from spectree import Response, SpecTree
 
 app = Flask(__name__)
@@ -26,14 +26,15 @@ class Data(BaseModel):
     limit: int = 5
     vip: bool
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "uid": "very_important_user",
                 "limit": 10,
                 "vip": True,
             }
         }
+    )
 
 
 class Language(str, Enum):
@@ -113,4 +114,4 @@ if __name__ == "__main__":
     """
     app.add_url_rule("/api/user", view_func=UserAPI.as_view("user_id"))
     spec.register(app)
-    app.run(port=8000)
+    app.run(port=4000)

--- a/examples/flask_demo.py
+++ b/examples/flask_demo.py
@@ -1,11 +1,11 @@
 from enum import Enum
 from random import random
 
-from common import File, FileResp, Query
 from flask import Flask, abort, jsonify, request
 from flask.views import MethodView
 from pydantic import BaseModel, ConfigDict, Field
 
+from examples.common import File, FileResp, Query
 from spectree import Response, SpecTree
 
 app = Flask(__name__)
@@ -114,4 +114,4 @@ if __name__ == "__main__":
     """
     app.add_url_rule("/api/user", view_func=UserAPI.as_view("user_id"))
     spec.register(app)
-    app.run(port=4000)
+    app.run(port=8000)

--- a/examples/quart_demo.py
+++ b/examples/quart_demo.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from random import random
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from quart import Quart, abort, jsonify, request
 from quart.views import MethodView
 
@@ -29,14 +29,15 @@ class Data(BaseModel):
     limit: int = 5
     vip: bool
 
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "uid": "very_important_user",
                 "limit": 10,
                 "vip": True,
             }
         }
+    )
 
 
 class Language(str, Enum):

--- a/examples/security_demo.py
+++ b/examples/security_demo.py
@@ -11,19 +11,19 @@ class Req(BaseModel):
 security_schemes = [
     SecurityScheme(
         name="PartnerID",
-        data=SecuritySchemeData.parse_obj(
+        data=SecuritySchemeData.model_validate(
             {"type": "apiKey", "name": "partner-id", "in": "header"}
         ),
     ),
     SecurityScheme(
         name="PartnerToken",
-        data=SecuritySchemeData.parse_obj(
+        data=SecuritySchemeData.model_validate(
             {"type": "apiKey", "name": "partner-access-token", "in": "header"}
         ),
     ),
     SecurityScheme(
         name="test_secure",
-        data=SecuritySchemeData.parse_obj(
+        data=SecuritySchemeData.model_validate(
             {
                 "type": "http",
                 "scheme": "bearer",
@@ -32,7 +32,7 @@ security_schemes = [
     ),
     SecurityScheme(
         name="auth_oauth2",
-        data=SecuritySchemeData.parse_obj(
+        data=SecuritySchemeData.model_validate(
             {
                 "type": "oauth2",
                 "flows": {

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -1,11 +1,11 @@
 import uvicorn
+from common import File, FileResp, Query
 from pydantic import BaseModel, Field
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
-from examples.common import File, FileResp, Query
 from spectree import Response, SpecTree
 
 spec = SpecTree("starlette")

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -1,11 +1,11 @@
 import uvicorn
-from common import File, FileResp, Query
 from pydantic import BaseModel, Field
 from starlette.applications import Starlette
 from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
+from examples.common import File, FileResp, Query
 from spectree import Response, SpecTree
 
 spec = SpecTree("starlette")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pydantic>=1.9.1",
+    "pydantic>=2.0",
+    "pydantic-settings"
 ]
 
 [project.optional-dependencies]
@@ -37,7 +38,7 @@ dev = [
     "syrupy>=4.0",
 ]
 email = [
-    "pydantic[email]>=1.2,<2",
+    "pydantic[email]>=2.0",
 ]
 falcon = [
     "falcon>=3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,11 @@ from setuptools import setup
 setup(
     name="spectree",
     install_requires=[
-        "pydantic>=1.2",
+        "pydantic>=2.0",
+        "pydantic-settings"
     ],
     extras_require={
-        "email": ["pydantic[email]>=1.2,<2"],
+        "email": ["pydantic[email]>=2.0"],
         "flask": ["flask"],
         "quart": ["quart"],
         "falcon": ["falcon>=3.0.0"],

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -138,7 +138,8 @@ class Configuration(BaseSettings):
                 "additional_query_string_params",
                 "use_basic_authentication_with_access_code_grant",
                 "use_pkce_with_authorization_code_grant",
-            }
+            },
+            mode="json",
         )
         config["use_basic_authentication_with_access_code_grant"] = (
             "true"
@@ -160,6 +161,7 @@ class Configuration(BaseSettings):
                 "contact",
                 "license",
             },
+            mode="json",
             exclude_none=True,
         )
         if info.get("terms_of_service") is not None:

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -229,7 +229,7 @@ class FalconPlugin(BasePlugin):
         if resp and resp.has_model():
             model = resp.find_model(_resp.status[:3])
             if model and isinstance(_resp.media, model):
-                _resp.media = _resp.media.model_dump()
+                _resp.media = _resp.media.model_dump(mode="json")
                 skip_validation = True
 
             if self._data_set_manually(_resp):
@@ -331,7 +331,7 @@ class FalconAsgiPlugin(FalconPlugin):
         if resp and resp.has_model():
             model = resp.find_model(_resp.status[:3])
             if model and isinstance(_resp.media, model):
-                _resp.media = _resp.media.model_dump()
+                _resp.media = _resp.media.model_dump(mode="json")
                 skip_validation = True
 
             if self._data_set_manually(_resp):

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -214,7 +214,7 @@ class FlaskPlugin(BasePlugin):
             expect_model = resp.find_model(status)
             if expect_model and isinstance(model, expect_model):
                 skip_validation = True
-                result = (model.model_dump(), status, *rest)
+                result = (model.model_dump(mode="json"), status, *rest)
 
         response = make_response(result)
 

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -222,7 +222,7 @@ class QuartPlugin(BasePlugin):
             expect_model = resp.find_model(status)
             if expect_model and isinstance(model, expect_model):
                 skip_validation = True
-                result = (model.model_dump(), status, *rest)
+                result = (model.model_dump(mode="json"), status, *rest)
 
         response = await make_response(result)
 

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -24,7 +24,7 @@ def PydanticResponse(content: BaseModel):
     class _PydanticResponse(JSONResponse):
         def render(self, content: BaseModel) -> bytes:
             self._model_class = content.__class__
-            return super().render(content.model_dump())
+            return super().render(content.model_dump(mode="json"))
 
     return _PydanticResponse(content)
 

--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -335,12 +335,15 @@ class SpecTree:
 
         if self.config.servers:
             spec["servers"] = [
-                server.model_dump(exclude_none=True) for server in self.config.servers
+                server.model_dump(exclude_none=True, mode="json")
+                for server in self.config.servers
             ]
 
         if self.config.security_schemes:
             spec["components"]["securitySchemes"] = {
-                scheme.name: scheme.data.model_dump(exclude_none=True, by_alias=True)
+                scheme.name: scheme.data.model_dump(
+                    exclude_none=True, by_alias=True, mode="json"
+                )
                 for scheme in self.config.security_schemes
             }
 

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -41,7 +41,6 @@
         "type": "object"
       },
       "Headers.7068f62.Language": {
-        "description": "An enumeration.",
         "enum": [
           "en-US",
           "zh-CN"
@@ -105,7 +104,6 @@
         "type": "object"
       },
       "Query.7068f62.Order": {
-        "description": "An enumeration.",
         "enum": [
           0,
           1
@@ -153,14 +151,25 @@
         "description": "Model of a validation error response element.",
         "properties": {
           "ctx": {
-            "title": "Error context",
-            "type": "object"
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Error context"
+          },
+          "input": {
+            "title": "Input provided for validation"
           },
           "loc": {
             "items": {
               "type": "string"
             },
-            "title": "Missing field name",
+            "title": "Error location",
             "type": "array"
           },
           "msg": {
@@ -170,12 +179,20 @@
           "type": {
             "title": "Error type",
             "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Error URL",
+            "type": "string"
           }
         },
         "required": [
+          "input",
           "loc",
           "msg",
-          "type"
+          "type",
+          "url"
         ],
         "title": "ValidationErrorElement",
         "type": "object"

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -59,7 +59,6 @@
         "type": "object"
       },
       "Headers.7068f62.Language": {
-        "description": "An enumeration.",
         "enum": [
           "en-US",
           "zh-CN"
@@ -123,7 +122,6 @@
         "type": "object"
       },
       "Query.7068f62.Order": {
-        "description": "An enumeration.",
         "enum": [
           0,
           1
@@ -171,14 +169,25 @@
         "description": "Model of a validation error response element.",
         "properties": {
           "ctx": {
-            "title": "Error context",
-            "type": "object"
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Error context"
+          },
+          "input": {
+            "title": "Input provided for validation"
           },
           "loc": {
             "items": {
               "type": "string"
             },
-            "title": "Missing field name",
+            "title": "Error location",
             "type": "array"
           },
           "msg": {
@@ -188,12 +197,20 @@
           "type": {
             "title": "Error type",
             "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Error URL",
+            "type": "string"
           }
         },
         "required": [
+          "input",
           "loc",
           "msg",
-          "type"
+          "type",
+          "url"
         ],
         "title": "ValidationErrorElement",
         "type": "object"

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -59,7 +59,6 @@
         "type": "object"
       },
       "Headers.7068f62.Language": {
-        "description": "An enumeration.",
         "enum": [
           "en-US",
           "zh-CN"
@@ -123,7 +122,6 @@
         "type": "object"
       },
       "Query.7068f62.Order": {
-        "description": "An enumeration.",
         "enum": [
           0,
           1
@@ -171,14 +169,25 @@
         "description": "Model of a validation error response element.",
         "properties": {
           "ctx": {
-            "title": "Error context",
-            "type": "object"
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Error context"
+          },
+          "input": {
+            "title": "Input provided for validation"
           },
           "loc": {
             "items": {
               "type": "string"
             },
-            "title": "Missing field name",
+            "title": "Error location",
             "type": "array"
           },
           "msg": {
@@ -188,12 +197,20 @@
           "type": {
             "title": "Error type",
             "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Error URL",
+            "type": "string"
           }
         },
         "required": [
+          "input",
           "loc",
           "msg",
-          "type"
+          "type",
+          "url"
         ],
         "title": "ValidationErrorElement",
         "type": "object"

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -59,7 +59,6 @@
         "type": "object"
       },
       "Headers.7068f62.Language": {
-        "description": "An enumeration.",
         "enum": [
           "en-US",
           "zh-CN"
@@ -123,7 +122,6 @@
         "type": "object"
       },
       "Query.7068f62.Order": {
-        "description": "An enumeration.",
         "enum": [
           0,
           1
@@ -171,14 +169,25 @@
         "description": "Model of a validation error response element.",
         "properties": {
           "ctx": {
-            "title": "Error context",
-            "type": "object"
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Error context"
+          },
+          "input": {
+            "title": "Input provided for validation"
           },
           "loc": {
             "items": {
               "type": "string"
             },
-            "title": "Missing field name",
+            "title": "Error location",
             "type": "array"
           },
           "msg": {
@@ -188,12 +197,20 @@
           "type": {
             "title": "Error type",
             "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Error URL",
+            "type": "string"
           }
         },
         "required": [
+          "input",
           "loc",
           "msg",
-          "type"
+          "type",
+          "url"
         ],
         "title": "ValidationErrorElement",
         "type": "object"

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -41,7 +41,6 @@
         "type": "object"
       },
       "Headers.7068f62.Language": {
-        "description": "An enumeration.",
         "enum": [
           "en-US",
           "zh-CN"
@@ -105,7 +104,6 @@
         "type": "object"
       },
       "Query.7068f62.Order": {
-        "description": "An enumeration.",
         "enum": [
           0,
           1
@@ -153,14 +151,25 @@
         "description": "Model of a validation error response element.",
         "properties": {
           "ctx": {
-            "title": "Error context",
-            "type": "object"
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Error context"
+          },
+          "input": {
+            "title": "Input provided for validation"
           },
           "loc": {
             "items": {
               "type": "string"
             },
-            "title": "Missing field name",
+            "title": "Error location",
             "type": "array"
           },
           "msg": {
@@ -170,12 +179,20 @@
           "type": {
             "title": "Error type",
             "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Error URL",
+            "type": "string"
           }
         },
         "required": [
+          "input",
           "loc",
           "msg",
-          "type"
+          "type",
+          "url"
         ],
         "title": "ValidationErrorElement",
         "type": "object"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,8 +66,8 @@ def test_update_security_scheme(secure_item: Type[SecurityScheme]):
     config = Configuration(
         security_schemes=[SecurityScheme(name=secure_item.name, data=secure_item.data)]
     )
-    assert config.model_dump()["security_schemes"] == [
-        {"name": secure_item.name, "data": secure_item.data.model_dump()}
+    assert config.model_dump(mode="json")["security_schemes"] == [
+        {"name": secure_item.name, "data": secure_item.data.model_dump(mode="json")}
     ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ def test_config_license():
         license={"name": "MIT", "url": "https://opensource.org/licenses/MIT"}
     )
     assert config.license.name == "MIT"
-    assert config.license.url == "https://opensource.org/licenses/MIT"
+    assert str(config.license.url) == "https://opensource.org/licenses/MIT"
 
     with pytest.raises(ValidationError):
         Configuration(license={"name": "MIT", "url": "url"})
@@ -30,7 +30,7 @@ def test_config_contact():
 
     config = Configuration(contact={"name": "John", "url": "https://example.com"})
     assert config.contact.name == "John"
-    assert config.contact.url == "https://example.com"
+    assert str(config.contact.url) == "https://example.com/"
 
     config = Configuration(contact={"name": "John", "email": "hello@github.com"})
     assert config.contact.name == "John"
@@ -66,8 +66,8 @@ def test_update_security_scheme(secure_item: Type[SecurityScheme]):
     config = Configuration(
         security_schemes=[SecurityScheme(name=secure_item.name, data=secure_item.data)]
     )
-    assert config.security_schemes == [
-        {"name": secure_item.name, "data": secure_item.data}
+    assert config.model_dump()["security_schemes"] == [
+        {"name": secure_item.name, "data": secure_item.data.model_dump()}
     ]
 
 
@@ -80,7 +80,7 @@ def test_update_security_schemes():
 @pytest.mark.parametrize(("secure_item"), SECURITY_SCHEMAS)
 def test_update_security_scheme_wrong_type(secure_item: SecurityScheme):
     # update and validate each schema type
-    with pytest.raises(ValidationError):
+    with pytest.raises(KeyError):
         secure_item.data.type += "_wrong"  # type: ignore
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,7 @@ def test_plugin_spec(api, snapshot_json):
         for m in (Query, JSON, Resp, Cookies, Headers)
     }
     for name, schema in models.items():
-        schema.pop("definitions", None)
+        schema.pop("$defs", None)
         assert api.spec["components"]["schemas"][name] == schema
 
     assert api.spec == snapshot_json(name="full_spec")

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -203,13 +203,15 @@ class ViewWithCustomSerializer:
         resp=Response(HTTP_200=Resp),
     )
     def on_get(self, req, resp):
-        resp.data = Resp(name="falcon", score=[1, 2, 3]).json().encode("utf-8")
+        resp.data = (
+            Resp(name="falcon", score=[1, 2, 3]).model_dump_json().encode("utf-8")
+        )
 
     @api.validate(
         resp=Response(HTTP_200=Resp),
     )
     def on_post(self, req, resp):
-        resp.text = Resp(name="falcon", score=[1, 2, 3]).json()
+        resp.text = Resp(name="falcon", score=[1, 2, 3]).model_dump_json()
 
 
 app = App()

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -140,13 +140,15 @@ class ViewWithCustomSerializer:
         resp=Response(HTTP_200=Resp),
     )
     async def on_get(self, req, resp):
-        resp.data = Resp(name="falcon", score=[1, 2, 3]).json().encode("utf-8")
+        resp.data = (
+            Resp(name="falcon", score=[1, 2, 3]).model_dump_json().encode("utf-8")
+        )
 
     @api.validate(
         resp=Response(HTTP_200=Resp),
     )
     async def on_post(self, req, resp):
-        resp.text = Resp(name="falcon", score=[1, 2, 3]).json()
+        resp.text = Resp(name="falcon", score=[1, 2, 3]).model_dump_json()
 
 
 app = App()

--- a/tests/test_plugin_starlette.py
+++ b/tests/test_plugin_starlette.py
@@ -365,7 +365,7 @@ def test_starlette_no_response(client):
     resp = client.get("/api/no_response")
     assert resp.status_code == 200, resp.text
 
-    resp = client.post("/api/no_response", json={"name": "starlette", "limit": 1})
+    resp = client.post("/api/no_response", json={"name": "starlette", "limit": "1"})
     assert resp.status_code == 200, resp.text
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -118,8 +118,10 @@ def test_list_model():
         {"name": "a", "limit": 1},
         {"name": "b", "limit": 2},
     ]
-    instance = model.parse_obj(data)
-    for i, item in enumerate(instance.dict()["__root__"]):
-        obj = JSON.parse_obj(item)
+    instance = model.model_validate(data)
+
+    print(instance.model_dump())
+    for i, item in enumerate(instance.model_dump()):
+        obj = JSON.model_validate(item)
         assert obj.name == data[i]["name"]
         assert obj.limit == data[i]["limit"]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -120,8 +120,7 @@ def test_list_model():
     ]
     instance = model.model_validate(data)
 
-    print(instance.model_dump())
-    for i, item in enumerate(instance.model_dump()):
+    for i, item in enumerate(instance.model_dump(mode="json")):
         obj = JSON.model_validate(item)
         assert obj.name == data[i]["name"]
         assert obj.limit == data[i]["limit"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -232,7 +232,7 @@ def test_parse_request():
 
 def test_parse_params():
     models = {
-        get_model_path_key("tests.common.DemoModel"): DemoModel.schema(
+        get_model_path_key("tests.common.DemoModel"): DemoModel.model_json_schema(
             ref_template="#/components/schemas/{model}"
         )
     }
@@ -251,7 +251,7 @@ def test_parse_params():
 
 def test_parse_params_with_route_param_keywords():
     models = {
-        get_model_path_key("tests.common.DemoQuery"): DemoQuery.schema(
+        get_model_path_key("tests.common.DemoQuery"): DemoQuery.model_json_schema(
             ref_template="#/components/schemas/{model}"
         )
     }


### PR DESCRIPTION
This will have to be tested more thoroughly of course, but I hope this is a good start to move towards pydantic v2 :)

Changes:
- New `BaseModel` method names, decorators, and config dict:
  * `model.parse_obj` -> `model.model_validate`
  * `model.dict` -> `model.model_dump(mode="json")`
  * `@root_validator` -> `@model_validator`
  * `@validator` -> `@field_validator`
  * `parse_raw(raw_stuff)` -> `model_validate(json.loads(raw_stuff))`
  * `schema` -> `model_json_schema`
  * `json` -> `model_dump_json`
  * `class Config: ...` -> `model_config = ConfigDict(...)`
- `BaseModel` subclasses using `__root__` switched to subclass `RootModel` with `root` annotation
- New fields for `ValidationErrorElement`: `input` and `url`
- Updated custom type definition for `BaseFile` ([thanks to flask-openapi3's implementation](https://github.com/luolingchun/flask-openapi3/blob/v3.x/flask_openapi3/models/file.py#L11))
- Response on `ValidationError` updated to use `err.json(indent=2)` instead of `jsonify(err.errors())` to avoid `TypeError: _ is not JSONSerializable` errors from the new `input` field (`indent=2` to keep response consistent to current)
- Update model schema definitions key from `definitions` -> `$defs`
- `req_validation_error.model.__name__` -> `req_validation_error.title`
- `pydantic.EmailStr.validate` -> `pydantic.validate_email`
