### PR TITLE
Support Pydantic v2 with v1 backport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL:=install
 
 SOURCE_FILES=spectree tests examples
+MYPY_SOURCE_FILES=spectree tests # temporary
 
 install:
 	pip install -U -e .[email,quart,flask,falcon,starlette,dev]
@@ -43,6 +44,6 @@ lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
 	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=15
-	mypy --install-types --non-interactive ${SOURCE_FILES}
+	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ import_test:
 test: import_test
 	pip install -U -e .[email,flask,quart,falcon,starlette]
 	pytest tests -vv -rs
+	pip install pydantic==1.10.11
+	pytest tests -vv -rs
 
 doc:
 	cd docs && make html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "pydantic>=1.2,<2",
+    "pydantic>=1.2,<3",
 ]
 
 [project.optional-dependencies]
@@ -37,7 +37,7 @@ dev = [
     "syrupy>=4.0",
 ]
 email = [
-    "pydantic[email]>=1.2,<2",
+    "pydantic[email]>=1.2,<3",
 ]
 falcon = [
     "falcon>=3.0.0",

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from setuptools import setup
 setup(
     name="spectree",
     install_requires=[
-        "pydantic>=1.2,<2",
+        "pydantic>=1.2,<3",
     ],
     extras_require={
-        "email": ["pydantic[email]>=1.2,<2"],
+        "email": ["pydantic[email]>=1.2,<3"],
         "flask": ["flask"],
         "quart": ["quart"],
         "falcon": ["falcon>=3.0.0"],

--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -1,0 +1,37 @@
+from pydantic.version import VERSION as PYDANTIC_VERSION
+
+PYDANTIC2 = PYDANTIC_VERSION.startswith("2")
+
+__all__ = [
+    "BaseModel",
+    "ValidationError",
+    "Field",
+    "root_validator",
+    "AnyUrl",
+    "BaseSettings",
+    "EmailStr",
+    "validator",
+]
+
+if PYDANTIC2:
+    from pydantic.v1 import (
+        AnyUrl,
+        BaseModel,
+        BaseSettings,
+        EmailStr,
+        Field,
+        ValidationError,
+        root_validator,
+        validator,
+    )
+else:
+    from pydantic import (  # type: ignore[no-redef,assignment]
+        AnyUrl,
+        BaseModel,
+        BaseSettings,
+        EmailStr,
+        Field,
+        ValidationError,
+        root_validator,
+        validator,
+    )

--- a/spectree/_types.py
+++ b/spectree/_types.py
@@ -11,8 +11,9 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel
 from typing_extensions import Protocol
+
+from ._pydantic import BaseModel
 
 ModelType = Type[BaseModel]
 OptionalModelType = Optional[ModelType]

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -2,8 +2,7 @@ import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, BaseSettings, EmailStr, root_validator
-
+from ._pydantic import AnyUrl, BaseModel, BaseSettings, EmailStr, root_validator
 from .models import SecurityScheme, Server
 from .page import DEFAULT_PAGE_TEMPLATES
 

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -2,7 +2,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence
 
-from pydantic import BaseModel, Field, root_validator, validator
+from ._pydantic import BaseModel, Field, root_validator, validator
 
 # OpenAPI names validation regexp
 OpenAPI_NAME_RE = re.compile(r"^[A-Za-z0-9-._]+")

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, get_type_hints
 
 from falcon import HTTP_400, HTTP_415, HTTPError
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
-from pydantic import ValidationError
 
+from .._pydantic import ValidationError
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 
 from flask import Blueprint, abort, current_app, jsonify, make_response, request
-from pydantic import BaseModel, ValidationError
 from werkzeug.routing import parse_converter_args
 
+from .._pydantic import BaseModel, ValidationError
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -1,10 +1,10 @@
 import inspect
 from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 
-from pydantic import BaseModel, ValidationError
 from quart import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
+from .._pydantic import BaseModel, ValidationError
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -4,12 +4,12 @@ from functools import partial
 from json import JSONDecodeError
 from typing import Any, Callable, Optional, get_type_hints
 
-from pydantic import ValidationError
 from starlette.convertors import CONVERTOR_TYPES
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import compile_path
 
+from .._pydantic import ValidationError
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin, Context

--- a/spectree/response.py
+++ b/spectree/response.py
@@ -1,8 +1,7 @@
 from http import HTTPStatus
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from pydantic import BaseModel
-
+from ._pydantic import BaseModel
 from ._types import ModelType, NamingStrategy, OptionalModelType
 from .utils import gen_list_model, get_model_key, parse_code
 

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -16,8 +16,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, ValidationError
-
+from ._pydantic import BaseModel, ValidationError
 from ._types import ModelType, MultiDict, NamingStrategy, NestedNamingStrategy
 
 # parse HTTP status code to get the code

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,9 +1,8 @@
 from enum import Enum, IntEnum
 from typing import Dict, List
 
-from pydantic import BaseModel, Field, root_validator
-
 from spectree import BaseFile, ExternalDocs, SecurityScheme, SecuritySchemeData, Tag
+from spectree._pydantic import BaseModel, Field, root_validator
 from spectree.utils import hash_module_path
 
 api_tag = Tag(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,9 @@ import string
 from typing import Type
 
 import pytest
-from pydantic import ValidationError
 
 from spectree import SecurityScheme
+from spectree._pydantic import ValidationError
 from spectree.config import Configuration, EmailFieldType
 
 from .common import SECURITY_SCHEMAS, WRONG_SECURITY_SCHEMAS_DATA

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,8 +1,8 @@
 from typing import List, get_type_hints
 
 import pytest
-from pydantic import BaseModel
 
+from spectree._pydantic import BaseModel
 from spectree.models import ValidationError
 from spectree.response import DEFAULT_CODE_DESC, Response
 from spectree.utils import gen_list_model

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,10 +1,10 @@
 import pytest
 from falcon import App as FalconApp
 from flask import Flask
-from pydantic import BaseModel
 from starlette.applications import Starlette
 
 from spectree import Response
+from spectree._pydantic import BaseModel
 from spectree.config import Configuration
 from spectree.models import Server, ValidationError
 from spectree.plugins.flask_plugin import FlaskPlugin


### PR DESCRIPTION
This is a less involved update to support pydantic v2. Compared to #324, this keeps the internals the same and uses the `pydantic.v1` backport for imports from v2. 