### PR TITLE
Support returning lists of unserialized models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=16
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=17
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=15
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=16
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/spectree/_types.py
+++ b/spectree/_types.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -15,7 +16,8 @@ from typing_extensions import Protocol
 
 from ._pydantic import BaseModel
 
-ModelType = Type[BaseModel]
+BaseModelSubclassType = TypeVar("BaseModelSubclassType", bound=BaseModel)
+ModelType = Type[BaseModelSubclassType]
 OptionalModelType = Optional[ModelType]
 NamingStrategy = Callable[[ModelType], str]
 NestedNamingStrategy = Callable[[str, str], str]

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -231,6 +231,9 @@ class FalconPlugin(BasePlugin):
             status = int(_resp.status[:3])
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
+                expected_list_item_type = resp.get_expected_list_item_type(status)
+                if all(isinstance(entry, expected_list_item_type) for entry in model):
+                    skip_validation = True
                 _resp.media = [
                     (entry.dict() if isinstance(entry, BaseModel) else entry)
                     for entry in model

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Mapping, Optional, get_type_hints
 
 from falcon import HTTP_400, HTTP_415, HTTPError
+from falcon import Response as FalconResponse
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
 
 from .._pydantic import BaseModel, ValidationError
@@ -188,6 +189,34 @@ class FalconPlugin(BasePlugin):
             req_form = {x.name: x.stream.read() for x in req.get_media()}
             req.context.form = form.parse_obj(req_form)
 
+    def response_validation(
+        self,
+        response_spec: Optional[Response],
+        falcon_response: FalconResponse,
+        skip_validation: bool,
+    ) -> None:
+        if response_spec and response_spec.has_model():
+            model = falcon_response.media
+            status = int(falcon_response.status[:3])
+            expect_model = response_spec.find_model(status)
+            if response_spec.expect_list_result(status) and isinstance(model, list):
+                expected_list_item_type = response_spec.get_expected_list_item_type(
+                    status
+                )
+                if all(isinstance(entry, expected_list_item_type) for entry in model):
+                    skip_validation = True
+                falcon_response.media = [
+                    (entry.dict() if isinstance(entry, BaseModel) else entry)
+                    for entry in model
+                ]
+            elif expect_model and isinstance(falcon_response.media, expect_model):
+                falcon_response.media = model.dict()
+                skip_validation = True
+            if self._data_set_manually(falcon_response):
+                skip_validation = True
+            if expect_model and not skip_validation:
+                expect_model.parse_obj(falcon_response.media)
+
     def validate(
         self,
         func: Callable,
@@ -226,32 +255,16 @@ class FalconPlugin(BasePlugin):
 
         func(*args, **kwargs)
 
-        if resp and resp.has_model():
-            model = _resp.media
-            status = int(_resp.status[:3])
-            expect_model = resp.find_model(status)
-            if resp.expect_list_result(status) and isinstance(model, list):
-                expected_list_item_type = resp.get_expected_list_item_type(status)
-                if all(isinstance(entry, expected_list_item_type) for entry in model):
-                    skip_validation = True
-                _resp.media = [
-                    (entry.dict() if isinstance(entry, BaseModel) else entry)
-                    for entry in model
-                ]
-            elif expect_model and isinstance(_resp.media, expect_model):
-                _resp.media = model.dict()
-                skip_validation = True
-
-            if self._data_set_manually(_resp):
-                skip_validation = True
-
-            if expect_model and not skip_validation:
-                try:
-                    expect_model.parse_obj(_resp.media)
-                except ValidationError as err:
-                    resp_validation_error = err
-                    _resp.status = HTTP_500
-                    _resp.media = err.errors()
+        try:
+            self.response_validation(
+                response_spec=resp,
+                falcon_response=_resp,
+                skip_validation=skip_validation,
+            )
+        except ValidationError as err:
+            resp_validation_error = err
+            _resp.status = HTTP_500
+            _resp.media = err.errors()
 
         after(_req, _resp, resp_validation_error, _self)
 
@@ -338,22 +351,15 @@ class FalconAsgiPlugin(FalconPlugin):
 
         await func(*args, **kwargs)
 
-        if resp and resp.has_model():
-            model = resp.find_model(_resp.status[:3])
-            if model and isinstance(_resp.media, model):
-                _resp.media = _resp.media.dict()
-                skip_validation = True
-
-            if self._data_set_manually(_resp):
-                skip_validation = True
-
-            model = resp.find_model(_resp.status[:3])
-            if model and not skip_validation:
-                try:
-                    model.parse_obj(_resp.media)
-                except ValidationError as err:
-                    resp_validation_error = err
-                    _resp.status = HTTP_500
-                    _resp.media = err.errors()
+        try:
+            self.response_validation(
+                response_spec=resp,
+                falcon_response=_resp,
+                skip_validation=skip_validation,
+            )
+        except ValidationError as err:
+            resp_validation_error = err
+            _resp.status = HTTP_500
+            _resp.media = err.errors()
 
         after(_req, _resp, resp_validation_error, _self)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -211,6 +211,9 @@ class FlaskPlugin(BasePlugin):
         if resp:
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
+                expected_list_item_type = resp.get_expected_list_item_type(status)
+                if all(isinstance(entry, expected_list_item_type) for entry in model):
+                    skip_validation = True
                 result = (
                     [
                         (entry.dict() if isinstance(entry, BaseModel) else entry)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -210,7 +210,16 @@ class FlaskPlugin(BasePlugin):
 
         if resp:
             expect_model = resp.find_model(status)
-            if expect_model and isinstance(model, expect_model):
+            if resp.expect_list_result(status) and isinstance(model, list):
+                result = (
+                    [
+                        (entry.dict() if isinstance(entry, BaseModel) else entry)
+                        for entry in model
+                    ],
+                    status,
+                    *rest,
+                )
+            elif expect_model and isinstance(model, expect_model):
                 skip_validation = True
                 result = (model.dict(), status, *rest)
 

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -223,6 +223,9 @@ class QuartPlugin(BasePlugin):
         if resp:
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
+                expected_list_item_type = resp.get_expected_list_item_type(status)
+                if all(isinstance(entry, expected_list_item_type) for entry in model):
+                    skip_validation = True
                 result = (
                     [
                         (entry.dict() if isinstance(entry, BaseModel) else entry)

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -234,7 +234,7 @@ class QuartPlugin(BasePlugin):
                     status,
                     *rest,
                 )
-            if expect_model and isinstance(model, expect_model):
+            elif expect_model and isinstance(model, expect_model):
                 skip_validation = True
                 result = (model.dict(), status, *rest)
 

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -222,6 +222,15 @@ class QuartPlugin(BasePlugin):
 
         if resp:
             expect_model = resp.find_model(status)
+            if resp.expect_list_result(status) and isinstance(model, list):
+                result = (
+                    [
+                        (entry.dict() if isinstance(entry, BaseModel) else entry)
+                        for entry in model
+                    ],
+                    status,
+                    *rest,
+                )
             if expect_model and isinstance(model, expect_model):
                 skip_validation = True
                 result = (model.dict(), status, *rest)

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import compile_path
 
-from .._pydantic import ValidationError
+from .._pydantic import BaseModel, ValidationError
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin, Context
@@ -22,7 +22,14 @@ def PydanticResponse(content):
     class _PydanticResponse(JSONResponse):
         def render(self, content) -> bytes:
             self._model_class = content.__class__
-            return super().render(content.dict())
+            return super().render(
+                [
+                    (entry.dict() if isinstance(entry, BaseModel) else entry)
+                    for entry in content
+                ]
+                if isinstance(content, list)
+                else content.dict()
+            )
 
     return _PydanticResponse(content)
 

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -67,6 +67,31 @@
         "title": "JSON",
         "type": "object"
       },
+      "JSONList.a9993e3": {
+        "items": {
+          "$ref": "#/components/schemas/JSONList.a9993e3.JSON"
+        },
+        "title": "JSONList",
+        "type": "array"
+      },
+      "JSONList.a9993e3.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "ListJSON.7068f62": {
         "items": {
           "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
@@ -324,6 +349,37 @@
         },
         "responses": {},
         "summary": "on_post <POST>",
+        "tags": []
+      }
+    },
+    "/api/return_list": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -85,6 +85,31 @@
         "title": "JSON",
         "type": "object"
       },
+      "JSONList.a9993e3": {
+        "items": {
+          "$ref": "#/components/schemas/JSONList.a9993e3.JSON"
+        },
+        "title": "JSONList",
+        "type": "array"
+      },
+      "JSONList.a9993e3.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "ListJSON.7068f62": {
         "items": {
           "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
@@ -277,6 +302,37 @@
         },
         "responses": {},
         "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/return_list": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_list <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -85,6 +85,31 @@
         "title": "JSON",
         "type": "object"
       },
+      "JSONList.a9993e3": {
+        "items": {
+          "$ref": "#/components/schemas/JSONList.a9993e3.JSON"
+        },
+        "title": "JSONList",
+        "type": "array"
+      },
+      "JSONList.a9993e3.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "ListJSON.7068f62": {
         "items": {
           "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
@@ -277,6 +302,37 @@
         },
         "responses": {},
         "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/return_list": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_list <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -85,6 +85,31 @@
         "title": "JSON",
         "type": "object"
       },
+      "JSONList.a9993e3": {
+        "items": {
+          "$ref": "#/components/schemas/JSONList.a9993e3.JSON"
+        },
+        "title": "JSONList",
+        "type": "array"
+      },
+      "JSONList.a9993e3.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "ListJSON.7068f62": {
         "items": {
           "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
@@ -282,6 +307,37 @@
         },
         "responses": {},
         "summary": "post <POST>",
+        "tags": []
+      }
+    },
+    "/api/return_list": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "get <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -67,6 +67,31 @@
         "title": "JSON",
         "type": "object"
       },
+      "JSONList.a9993e3": {
+        "items": {
+          "$ref": "#/components/schemas/JSONList.a9993e3.JSON"
+        },
+        "title": "JSONList",
+        "type": "array"
+      },
+      "JSONList.a9993e3.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "ListJSON.7068f62": {
         "items": {
           "$ref": "#/components/schemas/ListJSON.7068f62.JSON"
@@ -287,6 +312,37 @@
           }
         },
         "summary": "no_response <POST>",
+        "tags": []
+      }
+    },
+    "/api/return_list": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_list <GET>",
         "tags": []
       }
     },

--- a/tests/flask_imports/__init__.py
+++ b/tests/flask_imports/__init__.py
@@ -2,6 +2,7 @@ from .dry_plugin_flask import (
     test_flask_doc,
     test_flask_list_json_request,
     test_flask_no_response,
+    test_flask_return_list_request,
     test_flask_return_model,
     test_flask_skip_validation,
     test_flask_upload_file,
@@ -18,4 +19,5 @@ __all__ = [
     "test_flask_no_response",
     "test_flask_upload_file",
     "test_flask_list_json_request",
+    "test_flask_return_list_request",
 ]

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -161,6 +161,16 @@ def test_flask_list_json_request(client):
     assert resp.status_code == 200, resp.data
 
 
+@pytest.mark.parametrize("pre_serialize", [False, True])
+def test_flask_return_list_request(client, pre_serialize: bool):
+    resp = client.get(f"/api/return_list?pre_serialize={int(pre_serialize)}")
+    assert resp.status_code == 200
+    assert resp.json == [
+        {"name": "user1", "limit": 1},
+        {"name": "user2", "limit": 2},
+    ]
+
+
 def test_flask_upload_file(client):
     file_content = "abcdef"
     data = {"file": (io.BytesIO(file_content.encode("utf-8")), "test.txt")}

--- a/tests/quart_imports/dry_plugin_quart.py
+++ b/tests/quart_imports/dry_plugin_quart.py
@@ -162,3 +162,15 @@ def test_quart_list_json_request(client):
         client.post("/api/list_json", json=[{"name": "foo", "limit": 1}])
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("pre_serialize", [False, True])
+def test_quart_return_list_request(client, pre_serialize: bool):
+    resp = asyncio.run(
+        client.get(f"/api/return_list?pre_serialize={int(pre_serialize)}")
+    )
+    assert resp.status_code == 200
+    assert resp.json == [
+        {"name": "user1", "limit": 1},
+        {"name": "user2", "limit": 2},
+    ]

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -1,4 +1,5 @@
 from random import randint
+from typing import List
 
 import pytest
 from falcon import App, testing
@@ -196,6 +197,16 @@ class ListJsonView:
         pass
 
 
+class ReturnListView:
+    name = "return list request view"
+
+    @api.validate(resp=Response(HTTP_200=List[JSON]))
+    def on_get(self, req, resp):
+        pre_serialize = bool(int(req.params.get("pre_serialize", 0)))
+        data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
+        resp.media = [entry.dict() if pre_serialize else entry for entry in data]
+
+
 class ViewWithCustomSerializer:
     name = "view with custom serializer"
 
@@ -222,6 +233,7 @@ app.add_route("/api/user_model/{name}", UserScoreModel())
 app.add_route("/api/no_response", NoResponseView())
 app.add_route("/api/file_upload", FileUploadView())
 app.add_route("/api/list_json", ListJsonView())
+app.add_route("/api/return_list", ReturnListView())
 app.add_route("/api/custom_serializer", ViewWithCustomSerializer())
 api.register(app)
 
@@ -322,6 +334,18 @@ def test_falcon_list_json_request_sync(client):
         json=[dict(name="foo", limit=1)],
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("pre_serialize", [False, True])
+def test_falcon_return_list_request_sync(client, pre_serialize: bool):
+    resp = client.simulate_request(
+        "GET", f"/api/return_list?pre_serialize={int(pre_serialize)}"
+    )
+    assert resp.status_code == 200
+    assert resp.json == [
+        {"name": "user1", "limit": 1},
+        {"name": "user2", "limit": 2},
+    ]
 
 
 @pytest.fixture

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -127,8 +127,9 @@ class ReturnListView:
 
     @api.validate(resp=Response(HTTP_200=List[JSON]))
     async def on_get(self, req, resp):
+        pre_serialize = bool(int(req.params.get("pre_serialize", 0)))
         data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
-        resp.media = [entry.dict() for entry in data]
+        resp.media = [entry.dict() if pre_serialize else entry for entry in data]
 
 
 class FileUploadView:
@@ -200,8 +201,11 @@ def test_falcon_list_json_request_async(client):
     assert resp.status_code == 200
 
 
-def test_falcon_return_list_request_async(client):
-    resp = client.simulate_request("GET", "/api/return_list")
+@pytest.mark.parametrize("pre_serialize", [False, True])
+def test_falcon_return_list_request_async(client, pre_serialize: bool):
+    resp = client.simulate_request(
+        "GET", f"/api/return_list?pre_serialize={int(pre_serialize)}"
+    )
     assert resp.status_code == 200
     assert resp.json == [
         {"name": "user1", "limit": 1},

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -1,4 +1,5 @@
 from random import randint
+from typing import List
 
 import pytest
 from flask import Flask, jsonify, request
@@ -166,6 +167,14 @@ def no_response():
 )
 def json_list():
     return {}
+
+
+@app.route("/api/return_list", methods=["GET"])
+@api.validate(resp=Response(HTTP_200=List[JSON]))
+def return_list():
+    pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
+    data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
+    return [entry.dict() if pre_serialize else entry for entry in data]
 
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -1,4 +1,5 @@
 from random import randint
+from typing import List
 
 import pytest
 from flask import Blueprint, Flask, jsonify, request
@@ -155,6 +156,14 @@ def no_response():
 )
 def list_json():
     return {}
+
+
+@app.route("/api/return_list", methods=["GET"])
+@api.validate(resp=Response(HTTP_200=List[JSON]))
+def return_list():
+    pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
+    data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
+    return [entry.dict() if pre_serialize else entry for entry in data]
 
 
 api.register(app)

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -1,4 +1,5 @@
 from random import randint
+from typing import List
 
 import pytest
 from flask import Flask, jsonify, request
@@ -168,6 +169,16 @@ class ListJsonView(MethodView):
         return {}
 
 
+class ReturnListView(MethodView):
+    @api.validate(
+        resp=Response(HTTP_200=List[JSON]),
+    )
+    def get(self):
+        pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
+        data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
+        return [entry.dict() if pre_serialize else entry for entry in data]
+
+
 app.add_url_rule("/ping", view_func=Ping.as_view("ping"))
 app.add_url_rule("/api/user/<name>", view_func=User.as_view("user"), methods=["POST"])
 app.add_url_rule(
@@ -201,6 +212,10 @@ app.add_url_rule(
 app.add_url_rule(
     "/api/list_json",
     view_func=ListJsonView.as_view("list_json_view"),
+)
+app.add_url_rule(
+    "/api/return_list",
+    view_func=ReturnListView.as_view("return_list_view"),
 )
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_plugin_quart.py
+++ b/tests/test_plugin_quart.py
@@ -1,4 +1,5 @@
 from random import randint
+from typing import List
 
 import pytest
 from quart import Quart, jsonify, request
@@ -148,6 +149,14 @@ async def no_response():
 )
 async def list_json():
     return {}
+
+
+@app.route("/api/return_list")
+@api.validate(resp=Response(HTTP_200=List[JSON]))
+def return_list():
+    pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
+    data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
+    return [entry.dict() if pre_serialize else entry for entry in data]
 
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -111,6 +111,8 @@ def test_list_model():
     resp = Response(HTTP_200=List[JSON])
     model = resp.find_model(200)
     expect_model = gen_list_model(JSON)
+    assert resp.expect_list_result(200)
+    assert not resp.expect_list_result(500)
     assert get_type_hints(model) == get_type_hints(expect_model)
     assert type(model) is type(expect_model)
     assert issubclass(model, BaseModel)


### PR DESCRIPTION
## Description

Currently, `spectree` only partially supports validation of list responses. For example:

```python
class User(BaseModel):
    user_id: str

@app.route()
@api.validate(
    resp=Response(HTTP_200=List[User])
)
def get_users():
    return [
        User(user_id="user1").dict(),  # pre-serialization of individual entries is required, or spectree crashes
        User(user_id="user2").dict()
    ]
```

You'll notice in particular that individual entries **must** currently be serialized before returning or `spectree` crashes. This is inconsistent with the rest of the interface, because it's perfectly okay to return models (without serializing them) - so why not list of models?

The change basically updates individual plugins to serialize individual list entries (when needed) before the final response is created. The change is conservative and the above logic is only applied when all of the below applies:

- Routes / responses that expect a list result.
- Result is indeed a list.
- Individual list entry is a `BaseModel` subclass.

I have not changed any of the existing validation logic in this case: we still rely on the generated root model for validation.

Change summary:

- Update the validation logic to support returning lists of models from endpoints (for all plugins). I have made sure that returning lists of serialized models remains supported.
- Small typing update so this `Response(HTTP_200=List[User])` no longer triggers IDEs / type validation frameworks.
- Added tests for this use case (for all plugins).