### PR TITLE
[Proposal] Support Pydantic root model responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=17
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=22
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=22
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=21
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -16,7 +16,10 @@ __all__ = [
     "EmailStr",
     "validator",
     "is_root_model",
+    "is_root_model_instance",
     "serialize_model_instance",
+    "is_base_model",
+    "is_base_model_instance",
 ]
 
 if PYDANTIC2:

--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -1,8 +1,10 @@
-from typing import Any, Optional, Type
+from typing import Any
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 PYDANTIC2 = PYDANTIC_VERSION.startswith("2")
+ROOT_FIELD = "__root__"
+
 
 __all__ = [
     "BaseModel",
@@ -14,6 +16,7 @@ __all__ = [
     "EmailStr",
     "validator",
     "is_root_model",
+    "serialize_model_instance",
 ]
 
 if PYDANTIC2:
@@ -40,5 +43,34 @@ else:
     )
 
 
-def is_root_model(value: Optional[Type[Any]]):
-    return value and issubclass(value, BaseModel) and "__root__" in value.__fields__
+def is_base_model(t: Any) -> bool:
+    """Check whether a type is a Pydantic BaseModel"""
+    try:
+        return issubclass(t, BaseModel)
+    except TypeError:
+        return False
+
+
+def is_base_model_instance(value: Any) -> bool:
+    """Check whether a value is a Pydantic BaseModel instance."""
+    return is_base_model(type(value))
+
+
+def is_root_model(t: Any) -> bool:
+    """Check whether a type is a Pydantic RootModel."""
+    return is_base_model(t) and ROOT_FIELD in t.__fields__
+
+
+def is_root_model_instance(value: Any):
+    """Check whether a value is a Pydantic RootModel instance."""
+    return is_root_model(type(value))
+
+
+def serialize_model_instance(value: BaseModel):
+    """Serialize a Pydantic BaseModel (equivalent of calling `.dict()` on a BaseModel,
+    but additionally takes care of stripping __root__ for root models.
+    """
+    serialized = value.dict()
+    if is_root_model_instance(value) and ROOT_FIELD in serialized:
+        return serialized[ROOT_FIELD]
+    return serialized

--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional, Type
+
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 PYDANTIC2 = PYDANTIC_VERSION.startswith("2")
@@ -11,6 +13,7 @@ __all__ = [
     "BaseSettings",
     "EmailStr",
     "validator",
+    "is_root_model",
 ]
 
 if PYDANTIC2:
@@ -35,3 +38,7 @@ else:
         root_validator,
         validator,
     )
+
+
+def is_root_model(value: Optional[Type[Any]]):
+    return value and issubclass(value, BaseModel) and "__root__" in value.__fields__

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -7,7 +7,12 @@ from falcon import HTTP_400, HTTP_415, HTTPError
 from falcon import Response as FalconResponse
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
 
-from .._pydantic import BaseModel, ValidationError, is_root_model
+from .._pydantic import (
+    BaseModel,
+    ValidationError,
+    is_root_model,
+    serialize_model_instance,
+)
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin
@@ -195,7 +200,7 @@ class FalconPlugin(BasePlugin):
         falcon_response: FalconResponse,
         skip_validation: bool,
     ) -> None:
-        if response_spec and response_spec.has_model():
+        if not skip_validation and response_spec and response_spec.has_model():
             model = falcon_response.media
             status = int(falcon_response.status[:3])
             expect_model = response_spec.find_model(status)
@@ -206,23 +211,31 @@ class FalconPlugin(BasePlugin):
                 if all(isinstance(entry, expected_list_item_type) for entry in model):
                     skip_validation = True
                 falcon_response.media = [
-                    (entry.dict() if isinstance(entry, BaseModel) else entry)
+                    (
+                        serialize_model_instance(entry)
+                        if isinstance(entry, BaseModel)
+                        else entry
+                    )
                     for entry in model
                 ]
-            elif expect_model and is_root_model(expect_model):
-                if not isinstance(model, expect_model):
-                    # Make it possible to return an instance of the model __root__ type
-                    # (i.e. not the root model itself).
-                    try:
-                        model = expect_model(__root__=model)
-                    except ValidationError:
-                        pass
-                if isinstance(model, expect_model):
+            elif (
+                expect_model
+                and is_root_model(expect_model)
+                and not isinstance(model, expect_model)
+            ):
+                # Make it possible to return an instance of the model __root__ type
+                # (i.e. not the root model itself).
+                try:
+                    model = expect_model(__root__=model)
+                except ValidationError:
+                    raise
+                else:
+                    falcon_response.media = serialize_model_instance(model)
                     skip_validation = True
-                    falcon_response.media = model.dict()["__root__"]
             elif expect_model and isinstance(falcon_response.media, expect_model):
-                falcon_response.media = model.dict()
+                falcon_response.media = serialize_model_instance(model)
                 skip_validation = True
+
             if self._data_set_manually(falcon_response):
                 skip_validation = True
             if expect_model and not skip_validation:

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -251,16 +251,18 @@ class FlaskPlugin(BasePlugin):
 
         response = make_response(result)
 
-        if resp and resp.has_model():
+        if resp and resp.has_model() and not resp_validation_error:
             model = resp.find_model(response.status_code)
             if model and not skip_validation:
                 try:
                     model.parse_obj(response.get_json())
                 except ValidationError as err:
                     resp_validation_error = err
-                    response = make_response(
-                        jsonify({"message": "response validation error"}), 500
-                    )
+
+        if resp_validation_error:
+            response = make_response(
+                jsonify({"message": "response validation error"}), 500
+            )
 
         after(request, response, resp_validation_error, None)
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -3,7 +3,12 @@ from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 from flask import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from .._pydantic import BaseModel, ValidationError, is_root_model
+from .._pydantic import (
+    BaseModel,
+    ValidationError,
+    is_root_model,
+    serialize_model_instance,
+)
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule
@@ -208,7 +213,7 @@ class FlaskPlugin(BasePlugin):
         else:
             model = result
 
-        if resp:
+        if not skip_validation and resp:
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
                 expected_list_item_type = resp.get_expected_list_item_type(status)
@@ -216,26 +221,33 @@ class FlaskPlugin(BasePlugin):
                     skip_validation = True
                 result = (
                     [
-                        (entry.dict() if isinstance(entry, BaseModel) else entry)
+                        (
+                            serialize_model_instance(entry)
+                            if isinstance(entry, BaseModel)
+                            else entry
+                        )
                         for entry in model
                     ],
                     status,
                     *rest,
                 )
-            elif expect_model and is_root_model(expect_model):
-                if not isinstance(model, expect_model):
-                    # Make it possible to return an instance of the model __root__ type
-                    # (i.e. not the root model itself).
-                    try:
-                        model = expect_model(__root__=model)
-                    except ValidationError:
-                        pass
-                if isinstance(model, expect_model):
+            elif (
+                expect_model
+                and is_root_model(expect_model)
+                and not isinstance(model, expect_model)
+            ):
+                # Make it possible to return an instance of the model __root__ type
+                # (i.e. not the root model itself).
+                try:
+                    model = expect_model(__root__=model)
+                except ValidationError as err:
+                    resp_validation_error = err
+                else:
                     skip_validation = True
-                    result = (model.dict()["__root__"], status, *rest)
+                    result = (serialize_model_instance(model), status, *rest)
             elif expect_model and isinstance(model, expect_model):
                 skip_validation = True
-                result = (model.dict(), status, *rest)
+                result = (serialize_model_instance(model), status, *rest)
 
         response = make_response(result)
 

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 
+import flask
 from flask import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
@@ -213,7 +214,7 @@ class FlaskPlugin(BasePlugin):
         else:
             model = result
 
-        if not skip_validation and resp:
+        if not skip_validation and resp and not isinstance(result, flask.Response):
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
                 expected_list_item_type = resp.get_expected_list_item_type(status)

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 from quart import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from .._pydantic import BaseModel, ValidationError
+from .._pydantic import BaseModel, ValidationError, is_root_model
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule
@@ -234,6 +234,17 @@ class QuartPlugin(BasePlugin):
                     status,
                     *rest,
                 )
+            elif expect_model and is_root_model(expect_model):
+                if not isinstance(model, expect_model):
+                    # Make it possible to return an instance of the model __root__ type
+                    # (i.e. not the root model itself).
+                    try:
+                        model = expect_model(__root__=model)
+                    except ValidationError:
+                        pass
+                if isinstance(model, expect_model):
+                    skip_validation = True
+                    result = (model.dict()["__root__"], status, *rest)
             elif expect_model and isinstance(model, expect_model):
                 skip_validation = True
                 result = (model.dict(), status, *rest)

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -4,7 +4,12 @@ from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 from quart import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from .._pydantic import BaseModel, ValidationError, is_root_model
+from .._pydantic import (
+    BaseModel,
+    ValidationError,
+    is_root_model,
+    serialize_model_instance,
+)
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule
@@ -220,7 +225,7 @@ class QuartPlugin(BasePlugin):
         else:
             model = result
 
-        if resp:
+        if not skip_validation and resp:
             expect_model = resp.find_model(status)
             if resp.expect_list_result(status) and isinstance(model, list):
                 expected_list_item_type = resp.get_expected_list_item_type(status)
@@ -228,39 +233,48 @@ class QuartPlugin(BasePlugin):
                     skip_validation = True
                 result = (
                     [
-                        (entry.dict() if isinstance(entry, BaseModel) else entry)
+                        (
+                            serialize_model_instance(entry)
+                            if isinstance(entry, BaseModel)
+                            else entry
+                        )
                         for entry in model
                     ],
                     status,
                     *rest,
                 )
-            elif expect_model and is_root_model(expect_model):
-                if not isinstance(model, expect_model):
-                    # Make it possible to return an instance of the model __root__ type
-                    # (i.e. not the root model itself).
-                    try:
-                        model = expect_model(__root__=model)
-                    except ValidationError:
-                        pass
-                if isinstance(model, expect_model):
+            elif (
+                expect_model
+                and is_root_model(expect_model)
+                and not isinstance(model, expect_model)
+            ):
+                # Make it possible to return an instance of the model __root__ type
+                # (i.e. not the root model itself).
+                try:
+                    model = expect_model(__root__=model)
+                except ValidationError as err:
+                    resp_validation_error = err
+                else:
                     skip_validation = True
-                    result = (model.dict()["__root__"], status, *rest)
+                    result = (serialize_model_instance(model), status, *rest)
             elif expect_model and isinstance(model, expect_model):
                 skip_validation = True
-                result = (model.dict(), status, *rest)
+                result = (serialize_model_instance(model), status, *rest)
 
         response = await make_response(result)
 
-        if resp and resp.has_model():
+        if resp and resp.has_model() and not resp_validation_error:
             model = resp.find_model(response.status_code)
             if model and not skip_validation:
                 try:
                     model.parse_obj(await response.get_json())
                 except ValidationError as err:
                     resp_validation_error = err
-                    response = await make_response(
-                        jsonify({"message": "response validation error"}), 500
-                    )
+
+        if resp_validation_error:
+            response = await make_response(
+                jsonify({"message": "response validation error"}), 500
+            )
 
         after(request, response, resp_validation_error, None)
 

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import compile_path
 
-from .._pydantic import BaseModel, ValidationError
+from .._pydantic import BaseModel, ValidationError, is_root_model
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin, Context
@@ -22,6 +22,8 @@ def PydanticResponse(content):
     class _PydanticResponse(JSONResponse):
         def render(self, content) -> bytes:
             self._model_class = content.__class__
+            if is_root_model(type(content)):
+                return super().render(content.dict()["__root__"])
             return super().render(
                 [
                     (entry.dict() if isinstance(entry, BaseModel) else entry)

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -159,6 +159,38 @@
         "title": "Resp",
         "type": "object"
       },
+      "RootResp.7068f62": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RootResp.7068f62.JSON"
+          },
+          {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "RootResp"
+      },
+      "RootResp.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "StrDict.7068f62": {
         "additionalProperties": {
           "type": "string"
@@ -363,6 +395,37 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/JSONList.a9993e3"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "on_get <GET>",
+        "tags": []
+      }
+    },
+    "/api/return_root": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_root",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootResp.7068f62"
                 }
               }
             },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -177,6 +177,38 @@
         "title": "Resp",
         "type": "object"
       },
+      "RootResp.7068f62": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RootResp.7068f62.JSON"
+          },
+          {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "RootResp"
+      },
+      "RootResp.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "StrDict.7068f62": {
         "additionalProperties": {
           "type": "string"
@@ -333,6 +365,37 @@
           }
         },
         "summary": "return_list <GET>",
+        "tags": []
+      }
+    },
+    "/api/return_root": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_root",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootResp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_root <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -177,6 +177,38 @@
         "title": "Resp",
         "type": "object"
       },
+      "RootResp.7068f62": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RootResp.7068f62.JSON"
+          },
+          {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "RootResp"
+      },
+      "RootResp.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "StrDict.7068f62": {
         "additionalProperties": {
           "type": "string"
@@ -333,6 +365,37 @@
           }
         },
         "summary": "return_list <GET>",
+        "tags": []
+      }
+    },
+    "/api/return_root": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_root",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootResp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_root <GET>",
         "tags": []
       }
     },

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -177,6 +177,38 @@
         "title": "Resp",
         "type": "object"
       },
+      "RootResp.7068f62": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RootResp.7068f62.JSON"
+          },
+          {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "RootResp"
+      },
+      "RootResp.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "StrDict.7068f62": {
         "additionalProperties": {
           "type": "string"

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -159,6 +159,38 @@
         "title": "Resp",
         "type": "object"
       },
+      "RootResp.7068f62": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RootResp.7068f62.JSON"
+          },
+          {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        ],
+        "title": "RootResp"
+      },
+      "RootResp.7068f62.JSON": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "limit"
+        ],
+        "title": "JSON",
+        "type": "object"
+      },
       "StrDict.7068f62": {
         "additionalProperties": {
           "type": "string"
@@ -343,6 +375,37 @@
           }
         },
         "summary": "return_list <GET>",
+        "tags": []
+      }
+    },
+    "/api/return_root": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_root",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootResp.7068f62"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_root <GET>",
         "tags": []
       }
     },

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,5 @@
 from enum import Enum, IntEnum
-from typing import Dict, List
+from typing import Any, Dict, List, Union
 
 from spectree import BaseFile, ExternalDocs, SecurityScheme, SecuritySchemeData, Tag
 from spectree._pydantic import BaseModel, Field, root_validator
@@ -44,6 +44,10 @@ class StrDict(BaseModel):
 class Resp(BaseModel):
     name: str
     score: List[int]
+
+
+class RootResp(BaseModel):
+    __root__: Union[JSON, List[int]]
 
 
 class Language(str, Enum):
@@ -177,3 +181,24 @@ def get_model_path_key(model_path: str) -> str:
         return model_name
 
     return f"{model_name}.{hash_module_path(module_path=model_path)}"
+
+
+def get_root_resp_data(pre_serialize: bool, return_what: str):
+    assert return_what in ("RootResp_JSON", "RootResp_List", "JSON", "List")
+    data: Any
+    if return_what == "RootResp_JSON":
+        data = RootResp(__root__=JSON(name="user1", limit=1))
+    elif return_what == "RootResp_List":
+        data = RootResp(__root__=[1, 2, 3, 4])
+    elif return_what == "JSON":
+        data = JSON(name="user1", limit=1)
+    elif return_what == "List":
+        data = [1, 2, 3, 4]
+        pre_serialize = False
+    else:
+        assert False
+    if pre_serialize:
+        data = data.dict()
+        if "__root__" in data:
+            data = data["__root__"]
+    return data

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -171,6 +171,21 @@ def test_flask_return_list_request(client, pre_serialize: bool):
     ]
 
 
+@pytest.mark.parametrize("pre_serialize", [False, True])
+@pytest.mark.parametrize(
+    "return_what", ["RootResp_JSON", "RootResp_List", "JSON", "List"]
+)
+def test_flask_return_root_request(client, pre_serialize: bool, return_what: str):
+    resp = client.get(
+        f"/api/return_root?pre_serialize={int(pre_serialize)}&return_what={return_what}"
+    )
+    assert resp.status_code == 200
+    if return_what in ("RootResp_JSON", "JSON"):
+        assert resp.json == {"name": "user1", "limit": 1}
+    elif return_what in ("RootResp_List", "List"):
+        assert resp.json == [1, 2, 3, 4]
+
+
 def test_flask_upload_file(client):
     file_content = "abcdef"
     data = {"file": (io.BytesIO(file_content.encode("utf-8")), "test.txt")}

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -14,8 +14,10 @@ from .common import (
     ListJSON,
     Query,
     Resp,
+    RootResp,
     StrDict,
     api_tag,
+    get_root_resp_data,
 )
 
 
@@ -207,6 +209,17 @@ class ReturnListView:
         resp.media = [entry.dict() if pre_serialize else entry for entry in data]
 
 
+class ReturnRootView:
+    name = "return root request view"
+
+    @api.validate(resp=Response(HTTP_200=RootResp))
+    def on_get(self, req, resp):
+        resp.media = get_root_resp_data(
+            pre_serialize=bool(int(req.params.get("pre_serialize", 0))),
+            return_what=req.params.get("return_what", "RootResp"),
+        )
+
+
 class ViewWithCustomSerializer:
     name = "view with custom serializer"
 
@@ -234,6 +247,7 @@ app.add_route("/api/no_response", NoResponseView())
 app.add_route("/api/file_upload", FileUploadView())
 app.add_route("/api/list_json", ListJsonView())
 app.add_route("/api/return_list", ReturnListView())
+app.add_route("/api/return_root", ReturnRootView())
 app.add_route("/api/custom_serializer", ViewWithCustomSerializer())
 api.register(app)
 
@@ -346,6 +360,23 @@ def test_falcon_return_list_request_sync(client, pre_serialize: bool):
         {"name": "user1", "limit": 1},
         {"name": "user2", "limit": 2},
     ]
+
+
+@pytest.mark.parametrize("pre_serialize", [False, True])
+@pytest.mark.parametrize(
+    "return_what", ["RootResp_JSON", "RootResp_List", "JSON", "List"]
+)
+def test_falcon_return_root_request_sync(client, pre_serialize: bool, return_what: str):
+    resp = client.simulate_request(
+        "GET",
+        f"/api/return_root?pre_serialize={int(pre_serialize)}"
+        f"&return_what={return_what}",
+    )
+    assert resp.status_code == 200
+    if return_what in ("RootResp_JSON", "JSON"):
+        assert resp.json == {"name": "user1", "limit": 1}
+    elif return_what in ("RootResp_List", "List"):
+        assert resp.json == [1, 2, 3, 4]
 
 
 @pytest.fixture

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -17,8 +17,10 @@ from .common import (
     Order,
     Query,
     Resp,
+    RootResp,
     StrDict,
     api_tag,
+    get_root_resp_data,
 )
 
 # import tests to execute
@@ -175,6 +177,15 @@ def return_list():
     pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
     data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
     return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+@app.route("/api/return_root", methods=["GET"])
+@api.validate(resp=Response(HTTP_200=RootResp))
+def return_root():
+    return get_root_resp_data(
+        pre_serialize=bool(int(request.args.get("pre_serialize", default=0))),
+        return_what=request.args.get("return_what", default="RootResp"),
+    )
 
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -16,9 +16,11 @@ from .common import (
     Order,
     Query,
     Resp,
+    RootResp,
     StrDict,
     api_tag,
     get_paths,
+    get_root_resp_data,
 )
 
 # import tests to execute
@@ -164,6 +166,15 @@ def return_list():
     pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
     data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
     return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+@app.route("/api/return_root", methods=["GET"])
+@api.validate(resp=Response(HTTP_200=RootResp))
+def return_root():
+    return get_root_resp_data(
+        pre_serialize=bool(int(request.args.get("pre_serialize", default=0))),
+        return_what=request.args.get("return_what", default="RootResp"),
+    )
 
 
 api.register(app)

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -50,7 +50,7 @@ def ping():
     """summary
 
     description"""
-    return jsonify(msg="pong")
+    return {"msg": "pong"}
 
 
 @app.route("/api/file_upload", methods=["POST"])

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -50,7 +50,7 @@ def ping():
     """summary
 
     description"""
-    return {"msg": "pong"}
+    return jsonify(msg="pong")
 
 
 @app.route("/api/file_upload", methods=["POST"])

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -17,8 +17,10 @@ from .common import (
     Order,
     Query,
     Resp,
+    RootResp,
     StrDict,
     api_tag,
+    get_root_resp_data,
 )
 
 # import tests to execute
@@ -177,6 +179,15 @@ class ReturnListView(MethodView):
         pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
         data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
         return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+class ReturnRootView(MethodView):
+    @api.validate(resp=Response(HTTP_200=RootResp))
+    def get(self):
+        return get_root_resp_data(
+            pre_serialize=bool(int(request.args.get("pre_serialize", default=0))),
+            return_what=request.args.get("return_what", default="RootResp"),
+        )
 
 
 app.add_url_rule("/ping", view_func=Ping.as_view("ping"))

--- a/tests/test_plugin_quart.py
+++ b/tests/test_plugin_quart.py
@@ -15,8 +15,10 @@ from .common import (
     Order,
     Query,
     Resp,
+    RootResp,
     StrDict,
     api_tag,
+    get_root_resp_data,
 )
 
 
@@ -157,6 +159,15 @@ def return_list():
     pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
     data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
     return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+@app.route("/api/return_root", methods=["GET"])
+@api.validate(resp=Response(HTTP_200=RootResp))
+def return_root():
+    return get_root_resp_data(
+        pre_serialize=bool(int(request.args.get("pre_serialize", default=0))),
+        return_what=request.args.get("return_what", default="RootResp"),
+    )
 
 
 # INFO: ensures that spec is calculated and cached _after_ registering

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Any, List
+
+import pytest
+
+from spectree._pydantic import BaseModel, is_root_model
+
+
+class DummyRootModel(BaseModel):
+    __root__: List[int]
+
+
+class SimpleModel(BaseModel):
+    user_id: int
+
+
+@dataclass
+class RootModelLookalike:
+    __root__: List[str]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (DummyRootModel, True),
+        (SimpleModel, False),
+        (RootModelLookalike, False),
+        (list, False),
+        (str, False),
+        (int, False),
+    ],
+)
+def test_is_root_model(value: Any, expected: bool):
+    assert is_root_model(value) is expected

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -3,7 +3,14 @@ from typing import Any, List
 
 import pytest
 
-from spectree._pydantic import BaseModel, is_root_model, serialize_model_instance
+from spectree._pydantic import (
+    BaseModel,
+    is_base_model,
+    is_base_model_instance,
+    is_root_model,
+    is_root_model_instance,
+    serialize_model_instance,
+)
 
 
 class DummyRootModel(BaseModel):
@@ -31,17 +38,92 @@ class RootModelLookalike:
     "value, expected",
     [
         (DummyRootModel, True),
+        (DummyRootModel(__root__=[1, 2, 3]), False),
         (NestedRootModel, True),
+        (NestedRootModel(__root__=DummyRootModel(__root__=[1, 2, 3])), False),
         (SimpleModel, False),
+        (SimpleModel(user_id=1), False),
         (RootModelLookalike, False),
+        (RootModelLookalike(__root__=["False"]), False),
         (list, False),
+        ([1, 2, 3], False),
         (str, False),
+        ("str", False),
         (int, False),
         (1, False),
     ],
 )
 def test_is_root_model(value: Any, expected: bool):
     assert is_root_model(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (DummyRootModel, False),
+        (DummyRootModel(__root__=[1, 2, 3]), True),
+        (NestedRootModel, False),
+        (NestedRootModel(__root__=DummyRootModel(__root__=[1, 2, 3])), True),
+        (SimpleModel, False),
+        (SimpleModel(user_id=1), False),
+        (RootModelLookalike, False),
+        (RootModelLookalike(__root__=["False"]), False),
+        (list, False),
+        ([1, 2, 3], False),
+        (str, False),
+        ("str", False),
+        (int, False),
+        (1, False),
+    ],
+)
+def test_is_root_model_instance(value, expected):
+    assert is_root_model_instance(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (DummyRootModel, True),
+        (DummyRootModel(__root__=[1, 2, 3]), False),
+        (NestedRootModel, True),
+        (NestedRootModel(__root__=DummyRootModel(__root__=[1, 2, 3])), False),
+        (SimpleModel, True),
+        (SimpleModel(user_id=1), False),
+        (RootModelLookalike, False),
+        (RootModelLookalike(__root__=["False"]), False),
+        (list, False),
+        ([1, 2, 3], False),
+        (str, False),
+        ("str", False),
+        (int, False),
+        (1, False),
+    ],
+)
+def test_is_base_model(value, expected):
+    assert is_base_model(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (DummyRootModel, False),
+        (DummyRootModel(__root__=[1, 2, 3]), True),
+        (NestedRootModel, False),
+        (NestedRootModel(__root__=DummyRootModel(__root__=[1, 2, 3])), True),
+        (SimpleModel, False),
+        (SimpleModel(user_id=1), True),
+        (RootModelLookalike, False),
+        (RootModelLookalike(__root__=["False"]), False),
+        (list, False),
+        ([1, 2, 3], False),
+        (str, False),
+        ("str", False),
+        (int, False),
+        (1, False),
+    ],
+)
+def test_is_base_model_instance(value, expected):
+    assert is_base_model_instance(value) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -26,7 +26,7 @@ class SimpleModel(BaseModel):
 
 
 class Users(BaseModel):
-    __root__: list[SimpleModel]
+    __root__: List[SimpleModel]
 
 
 @dataclass

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -3,15 +3,23 @@ from typing import Any, List
 
 import pytest
 
-from spectree._pydantic import BaseModel, is_root_model
+from spectree._pydantic import BaseModel, is_root_model, serialize_model_instance
 
 
 class DummyRootModel(BaseModel):
     __root__: List[int]
 
 
+class NestedRootModel(BaseModel):
+    __root__: DummyRootModel
+
+
 class SimpleModel(BaseModel):
     user_id: int
+
+
+class Users(BaseModel):
+    __root__: list[SimpleModel]
 
 
 @dataclass
@@ -23,12 +31,35 @@ class RootModelLookalike:
     "value, expected",
     [
         (DummyRootModel, True),
+        (NestedRootModel, True),
         (SimpleModel, False),
         (RootModelLookalike, False),
         (list, False),
         (str, False),
         (int, False),
+        (1, False),
     ],
 )
 def test_is_root_model(value: Any, expected: bool):
     assert is_root_model(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (SimpleModel(user_id=1), {"user_id": 1}),
+        (DummyRootModel(__root__=[1, 2, 3]), [1, 2, 3]),
+        (NestedRootModel(__root__=DummyRootModel(__root__=[1, 2, 3])), [1, 2, 3]),
+        (
+            Users(
+                __root__=[
+                    SimpleModel(user_id=1),
+                    SimpleModel(user_id=2),
+                ]
+            ),
+            [{"user_id": 1}, {"user_id": 2}],
+        ),
+    ],
+)
+def test_serialize_model_instance(value, expected):
+    assert serialize_model_instance(value) == expected


### PR DESCRIPTION
## Description

Spectree currently does not correctly support using Pydantic root models as response types. Specifying/returning a root model leads to serialisation issues. Couple of examples:

```python
class ApplicationError(BaseModel):
    message: str


class User(BaseModel):
    user_id: int


class GetUsersResponse(BaseModel):
    __root__: Union[list[User], ApplicationError]


@validate(resp=Response(HTTP_200=GetUsersResponse))
def get_users():
    # Case 1
    # Bad: {"__root__": [{"user_id": 1, "user_id": 2}]} 
    # Expected: [{"user_id": 1, "user_id": 2}])
    return GetUsersResponse(__root__=[User(user_id: 1), User(user_id: 2)])

    # Case 2
    # Bad: {"__root__": {"message": "error"}}
    # Expected: {"message": "error"}
    return GetUsersResponse(__root__=ApplicationError(message="error"))

    # Case 3
    # Bad: crashes (because list does not have .dict())
    # Expected: [{"user_id": 1, "user_id": 2}]
    return [User(user_id: 1), User(user_id: 2)]]  

    # Case 4
    # Ok: {"message": "error"} (although validation is not skipped)
    return ApplicationError(message="error")  
```

This change adds full support for using root model for responses, and makes it possible to:

- Return root model instances directly, in which case validation is skipped entirely. Serialisation has been fixed such that `__root__` is no longer present in the response.
- Return instances matching the type specified by `__root__` in the root model (such as returning a list of `User` models like in the example above). In this case, lightweight validation is carried out prior to serialisation, and the final validation is skipped. This is implemented such that non-BaseModel instances returned in views are still serialised correctly (see case 3 above).