### PR TITLE
Unify response validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=19
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=15
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ format:
 lint:
 	isort --check --diff --project=spectree ${SOURCE_FILES}
 	black --check --diff ${SOURCE_FILES}
-	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=21
+	flake8 ${SOURCE_FILES} --count --show-source --statistics --ignore=D203,E203,W503 --max-line-length=88 --max-complexity=19
 	mypy --install-types --non-interactive ${MYPY_SOURCE_FILES}
 
 .PHONY: test doc

--- a/spectree/_types.py
+++ b/spectree/_types.py
@@ -41,3 +41,6 @@ class FunctionDecorator(Protocol):
     deprecated: bool
     path_parameter_descriptions: Optional[Mapping[str, str]]
     _decorator: Any
+
+
+JsonType = Union[None, int, str, bool, List["JsonType"], Dict[str, "JsonType"]]

--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -8,9 +9,11 @@ from typing import (
     NamedTuple,
     Optional,
     TypeVar,
+    Union,
 )
 
-from .._types import ModelType
+from .._pydantic import ValidationError, is_root_model, serialize_model_instance
+from .._types import JsonType, ModelType, OptionalModelType
 from ..config import Configuration
 from ..response import Response
 
@@ -122,3 +125,65 @@ class BasePlugin(Generic[BackendRoute]):
         if not operation_id:
             operation_id = f"{method.lower()}_{path.replace('/', '_')}"
         return operation_id
+
+
+@dataclass(frozen=True)
+class RawResponsePayload:
+    payload: Union[JsonType, bytes]
+
+
+@dataclass(frozen=True)
+class ResponseValidationResult:
+    validated_response_payload: Any
+
+
+def validate_response(
+    skip_validation: bool,
+    validation_model: OptionalModelType,
+    response_payload: Any,
+):
+    """Validate a given `response_payload` against a `validation_model`.
+
+    :param skip_validation: When set to true, validation is not carried out
+        and the input `response_payload` is returned as-is. This is equivalent
+        to not providing a `validation_model`.
+    :param validation_model: Pydantic model used to validate the provided
+        `response_payload`.
+    :param response_payload: Validated response payload. A `RawResponsePayload`
+        should be provided when the plugin view function returned an already
+        JSON-serialized response payload.
+    """
+    final_response_payload = None
+    if isinstance(response_payload, RawResponsePayload):
+        final_response_payload = response_payload.payload
+    elif skip_validation or validation_model is None:
+        final_response_payload = response_payload
+
+    if not skip_validation and validation_model and not final_response_payload:
+        if is_root_model(validation_model) and not isinstance(
+            response_payload, validation_model
+        ):
+            # Make it possible to return an instance of the model __root__ type
+            # (i.e. not the root model itself).
+            try:
+                response_payload = validation_model(__root__=response_payload)
+            except ValidationError:
+                raise
+            else:
+                skip_validation = True
+                final_response_payload = serialize_model_instance(response_payload)
+        elif isinstance(response_payload, validation_model):
+            skip_validation = True
+            final_response_payload = serialize_model_instance(response_payload)
+        else:
+            final_response_payload = response_payload
+
+    if validation_model and not skip_validation:
+        validator = (
+            validation_model.parse_raw
+            if isinstance(final_response_payload, bytes)
+            else validation_model.parse_obj
+        )
+        validator(final_response_payload)
+
+    return ResponseValidationResult(validated_response_payload=final_response_payload)

--- a/spectree/plugins/base.py
+++ b/spectree/plugins/base.py
@@ -134,7 +134,7 @@ class RawResponsePayload:
 
 @dataclass(frozen=True)
 class ResponseValidationResult:
-    validated_response_payload: Any
+    payload: Any
 
 
 def validate_response(
@@ -160,7 +160,10 @@ def validate_response(
         final_response_payload = response_payload
 
     if not skip_validation and validation_model and not final_response_payload:
-        if is_root_model(validation_model) and not isinstance(
+        if isinstance(response_payload, validation_model):
+            skip_validation = True
+            final_response_payload = serialize_model_instance(response_payload)
+        elif is_root_model(validation_model) and not isinstance(
             response_payload, validation_model
         ):
             # Make it possible to return an instance of the model __root__ type
@@ -172,9 +175,6 @@ def validate_response(
             else:
                 skip_validation = True
                 final_response_payload = serialize_model_instance(response_payload)
-        elif isinstance(response_payload, validation_model):
-            skip_validation = True
-            final_response_payload = serialize_model_instance(response_payload)
         else:
             final_response_payload = response_payload
 
@@ -186,4 +186,4 @@ def validate_response(
         )
         validator(final_response_payload)
 
-    return ResponseValidationResult(validated_response_payload=final_response_payload)
+    return ResponseValidationResult(payload=final_response_payload)

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -7,12 +7,7 @@ from falcon import HTTP_400, HTTP_415, HTTPError
 from falcon import Response as FalconResponse
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
 
-from .._pydantic import (
-    BaseModel,
-    ValidationError,
-    is_root_model,
-    serialize_model_instance,
-)
+from .._pydantic import ValidationError, is_root_model, serialize_model_instance
 from .._types import ModelType
 from ..response import Response
 from .base import BasePlugin
@@ -204,21 +199,7 @@ class FalconPlugin(BasePlugin):
             model = falcon_response.media
             status = int(falcon_response.status[:3])
             expect_model = response_spec.find_model(status)
-            if response_spec.expect_list_result(status) and isinstance(model, list):
-                expected_list_item_type = response_spec.get_expected_list_item_type(
-                    status
-                )
-                if all(isinstance(entry, expected_list_item_type) for entry in model):
-                    skip_validation = True
-                falcon_response.media = [
-                    (
-                        serialize_model_instance(entry)
-                        if isinstance(entry, BaseModel)
-                        else entry
-                    )
-                    for entry in model
-                ]
-            elif (
+            if (
                 expect_model
                 and is_root_model(expect_model)
                 and not isinstance(model, expect_model)

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -4,13 +4,12 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Mapping, Optional, get_type_hints
 
 from falcon import HTTP_400, HTTP_415, HTTPError
-from falcon import Response as FalconResponse
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
 
-from .._pydantic import ValidationError, is_root_model, serialize_model_instance
+from .._pydantic import ValidationError
 from .._types import ModelType
 from ..response import Response
-from .base import BasePlugin
+from .base import BasePlugin, validate_response
 
 
 class OpenAPI:
@@ -189,39 +188,6 @@ class FalconPlugin(BasePlugin):
             req_form = {x.name: x.stream.read() for x in req.get_media()}
             req.context.form = form.parse_obj(req_form)
 
-    def response_validation(
-        self,
-        response_spec: Optional[Response],
-        falcon_response: FalconResponse,
-        skip_validation: bool,
-    ) -> None:
-        if not skip_validation and response_spec and response_spec.has_model():
-            model = falcon_response.media
-            status = int(falcon_response.status[:3])
-            expect_model = response_spec.find_model(status)
-            if (
-                expect_model
-                and is_root_model(expect_model)
-                and not isinstance(model, expect_model)
-            ):
-                # Make it possible to return an instance of the model __root__ type
-                # (i.e. not the root model itself).
-                try:
-                    model = expect_model(__root__=model)
-                except ValidationError:
-                    raise
-                else:
-                    falcon_response.media = serialize_model_instance(model)
-                    skip_validation = True
-            elif expect_model and isinstance(falcon_response.media, expect_model):
-                falcon_response.media = serialize_model_instance(model)
-                skip_validation = True
-
-            if self._data_set_manually(falcon_response):
-                skip_validation = True
-            if expect_model and not skip_validation:
-                expect_model.parse_obj(falcon_response.media)
-
     def validate(
         self,
         func: Callable,
@@ -260,20 +226,25 @@ class FalconPlugin(BasePlugin):
 
         func(*args, **kwargs)
 
-        try:
-            self.response_validation(
-                response_spec=resp,
-                falcon_response=_resp,
-                skip_validation=skip_validation,
-            )
-        except ValidationError as err:
-            resp_validation_error = err
-            _resp.status = HTTP_500
-            _resp.media = err.errors()
+        if not self._data_set_manually(_resp):
+            try:
+                status = int(_resp.status[:3])
+                response_validation_result = validate_response(
+                    skip_validation=skip_validation,
+                    validation_model=resp.find_model(status) if resp else None,
+                    response_payload=_resp.media,
+                )
+            except ValidationError as err:
+                resp_validation_error = err
+                _resp.status = HTTP_500
+                _resp.media = err.errors()
+            else:
+                _resp.media = response_validation_result.validated_response_payload
 
         after(_req, _resp, resp_validation_error, _self)
 
-    def _data_set_manually(self, resp):
+    @staticmethod
+    def _data_set_manually(resp):
         return (resp.text is not None or resp.data is not None) and resp.media is None
 
     def bypass(self, func, method):
@@ -356,15 +327,19 @@ class FalconAsgiPlugin(FalconPlugin):
 
         await func(*args, **kwargs)
 
-        try:
-            self.response_validation(
-                response_spec=resp,
-                falcon_response=_resp,
-                skip_validation=skip_validation,
-            )
-        except ValidationError as err:
-            resp_validation_error = err
-            _resp.status = HTTP_500
-            _resp.media = err.errors()
+        if not self._data_set_manually(_resp):
+            try:
+                status = int(_resp.status[:3])
+                response_validation_result = validate_response(
+                    skip_validation=skip_validation,
+                    validation_model=resp.find_model(status) if resp else None,
+                    response_payload=_resp.media,
+                )
+            except ValidationError as err:
+                resp_validation_error = err
+                _resp.status = HTTP_500
+                _resp.media = err.errors()
+            else:
+                _resp.media = response_validation_result.validated_response_payload
 
         after(_req, _resp, resp_validation_error, _self)

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -239,7 +239,7 @@ class FalconPlugin(BasePlugin):
                 _resp.status = HTTP_500
                 _resp.media = err.errors()
             else:
-                _resp.media = response_validation_result.validated_response_payload
+                _resp.media = response_validation_result.payload
 
         after(_req, _resp, resp_validation_error, _self)
 
@@ -340,6 +340,6 @@ class FalconAsgiPlugin(FalconPlugin):
                 _resp.status = HTTP_500
                 _resp.media = err.errors()
             else:
-                _resp.media = response_validation_result.validated_response_payload
+                _resp.media = response_validation_result.payload
 
         after(_req, _resp, resp_validation_error, _self)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -4,16 +4,11 @@ import flask
 from flask import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from .._pydantic import (
-    BaseModel,
-    ValidationError,
-    is_root_model,
-    serialize_model_instance,
-)
+from .._pydantic import ValidationError
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule
-from .base import BasePlugin, Context
+from .base import BasePlugin, Context, RawResponsePayload, validate_response
 
 
 class FlaskPlugin(BasePlugin):
@@ -206,47 +201,38 @@ class FlaskPlugin(BasePlugin):
 
         status = 200
         rest = []
-        if resp and isinstance(result, tuple) and isinstance(result[0], BaseModel):
+        if resp and isinstance(result, tuple):
             if len(result) > 1:
-                model, status, *rest = result
+                response_payload, status, *rest = result
             else:
-                model = result[0]
+                response_payload = result[0]
         else:
-            model = result
+            response_payload = result
 
-        if not skip_validation and resp and not isinstance(result, flask.Response):
-            expect_model = resp.find_model(status)
-            if (
-                expect_model
-                and is_root_model(expect_model)
-                and not isinstance(model, expect_model)
-            ):
-                # Make it possible to return an instance of the model __root__ type
-                # (i.e. not the root model itself).
-                try:
-                    model = expect_model(__root__=model)
-                except ValidationError as err:
-                    resp_validation_error = err
-                else:
-                    skip_validation = True
-                    result = (serialize_model_instance(model), status, *rest)
-            elif expect_model and isinstance(model, expect_model):
-                skip_validation = True
-                result = (serialize_model_instance(model), status, *rest)
-
-        response = make_response(result)
-
-        if resp and resp.has_model() and not resp_validation_error:
-            model = resp.find_model(response.status_code)
-            if model and not skip_validation:
-                try:
-                    model.parse_obj(response.get_json())
-                except ValidationError as err:
-                    resp_validation_error = err
-
-        if resp_validation_error:
+        try:
+            response_validation_result = validate_response(
+                skip_validation=skip_validation,
+                validation_model=resp.find_model(status) if resp else None,
+                response_payload=(
+                    RawResponsePayload(payload=response_payload.get_json())
+                    if (
+                        isinstance(response_payload, flask.Response)
+                        and not skip_validation
+                    )
+                    else response_payload
+                ),
+            )
+        except ValidationError:
             response = make_response(
                 jsonify({"message": "response validation error"}), 500
+            )
+        else:
+            response = make_response(
+                (
+                    response_validation_result.validated_response_payload,
+                    status,
+                    *rest,
+                )
             )
 
         after(request, response, resp_validation_error, None)

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -229,7 +229,7 @@ class FlaskPlugin(BasePlugin):
         else:
             response = make_response(
                 (
-                    response_validation_result.validated_response_payload,
+                    response_validation_result.payload,
                     status,
                     *rest,
                 )

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -216,23 +216,7 @@ class FlaskPlugin(BasePlugin):
 
         if not skip_validation and resp and not isinstance(result, flask.Response):
             expect_model = resp.find_model(status)
-            if resp.expect_list_result(status) and isinstance(model, list):
-                expected_list_item_type = resp.get_expected_list_item_type(status)
-                if all(isinstance(entry, expected_list_item_type) for entry in model):
-                    skip_validation = True
-                result = (
-                    [
-                        (
-                            serialize_model_instance(entry)
-                            if isinstance(entry, BaseModel)
-                            else entry
-                        )
-                        for entry in model
-                    ],
-                    status,
-                    *rest,
-                )
-            elif (
+            if (
                 expect_model
                 and is_root_model(expect_model)
                 and not isinstance(model, expect_model)

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -1,19 +1,15 @@
 import inspect
 from typing import Any, Callable, Mapping, Optional, Tuple, get_type_hints
 
+import quart
 from quart import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from .._pydantic import (
-    BaseModel,
-    ValidationError,
-    is_root_model,
-    serialize_model_instance,
-)
+from .._pydantic import ValidationError
 from .._types import ModelType
 from ..response import Response
 from ..utils import get_multidict_items, werkzeug_parse_rule
-from .base import BasePlugin, Context
+from .base import BasePlugin, Context, RawResponsePayload, validate_response
 
 
 class QuartPlugin(BasePlugin):
@@ -217,47 +213,40 @@ class QuartPlugin(BasePlugin):
 
         status = 200
         rest = []
-        if resp and isinstance(result, tuple) and isinstance(result[0], BaseModel):
+        if resp and isinstance(result, tuple):
             if len(result) > 1:
-                model, status, *rest = result
+                response_payload, status, *rest = result
             else:
-                model = result[0]
+                response_payload = result[0]
         else:
-            model = result
+            response_payload = result
 
-        if not skip_validation and resp:
-            expect_model = resp.find_model(status)
-            if (
-                expect_model
-                and is_root_model(expect_model)
-                and not isinstance(model, expect_model)
-            ):
-                # Make it possible to return an instance of the model __root__ type
-                # (i.e. not the root model itself).
-                try:
-                    model = expect_model(__root__=model)
-                except ValidationError as err:
-                    resp_validation_error = err
-                else:
-                    skip_validation = True
-                    result = (serialize_model_instance(model), status, *rest)
-            elif expect_model and isinstance(model, expect_model):
-                skip_validation = True
-                result = (serialize_model_instance(model), status, *rest)
-
-        response = await make_response(result)
-
-        if resp and resp.has_model() and not resp_validation_error:
-            model = resp.find_model(response.status_code)
-            if model and not skip_validation:
-                try:
-                    model.parse_obj(await response.get_json())
-                except ValidationError as err:
-                    resp_validation_error = err
-
-        if resp_validation_error:
+        try:
+            response_validation_result = validate_response(
+                skip_validation=skip_validation,
+                validation_model=resp.find_model(status) if resp else None,
+                response_payload=(
+                    RawResponsePayload(
+                        payload=(await response.get_json()) if response else None
+                    )
+                    if (
+                        isinstance(response_payload, quart.Response)
+                        and not skip_validation
+                    )
+                    else response_payload
+                ),
+            )
+        except ValidationError:
             response = await make_response(
                 jsonify({"message": "response validation error"}), 500
+            )
+        else:
+            response = await make_response(
+                (
+                    response_validation_result.validated_response_payload,
+                    status,
+                    *rest,
+                )
             )
 
         after(request, response, resp_validation_error, None)

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -243,7 +243,7 @@ class QuartPlugin(BasePlugin):
         else:
             response = await make_response(
                 (
-                    response_validation_result.validated_response_payload,
+                    response_validation_result.payload,
                     status,
                     *rest,
                 )

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -227,23 +227,7 @@ class QuartPlugin(BasePlugin):
 
         if not skip_validation and resp:
             expect_model = resp.find_model(status)
-            if resp.expect_list_result(status) and isinstance(model, list):
-                expected_list_item_type = resp.get_expected_list_item_type(status)
-                if all(isinstance(entry, expected_list_item_type) for entry in model):
-                    skip_validation = True
-                result = (
-                    [
-                        (
-                            serialize_model_instance(entry)
-                            if isinstance(entry, BaseModel)
-                            else entry
-                        )
-                        for entry in model
-                    ],
-                    status,
-                    *rest,
-                )
-            elif (
+            if (
                 expect_model
                 and is_root_model(expect_model)
                 and not isinstance(model, expect_model)

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -18,21 +18,16 @@ METHODS = {"get", "post", "put", "patch", "delete"}
 Route = namedtuple("Route", ["path", "methods", "func"])
 
 
+class _PydanticResponseModel(BaseModel):
+    __root__: Any
+
+
 def PydanticResponse(content):
     class _PydanticResponse(JSONResponse):
         def render(self, content) -> bytes:
             self._model_class = content.__class__
             return super().render(
-                [
-                    (
-                        serialize_model_instance(entry)
-                        if isinstance(entry, BaseModel)
-                        else entry
-                    )
-                    for entry in content
-                ]
-                if isinstance(content, list)
-                else serialize_model_instance(content)
+                serialize_model_instance(_PydanticResponseModel(__root__=content))
             )
 
     return _PydanticResponse(content)

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -763,7 +763,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "202": {
             "content": {
               "application/json": {
                 "schema": {
@@ -771,7 +771,7 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Accepted"
           },
           "422": {
             "content": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -763,7 +763,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "202": {
             "content": {
               "application/json": {
                 "schema": {
@@ -771,7 +771,7 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Accepted"
           },
           "422": {
             "content": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -747,7 +747,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "202": {
             "content": {
               "application/json": {
                 "schema": {
@@ -755,7 +755,7 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Accepted"
           },
           "422": {
             "content": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -763,7 +763,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "202": {
             "content": {
               "application/json": {
                 "schema": {
@@ -771,7 +771,7 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Accepted"
           },
           "422": {
             "content": {

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1,0 +1,171 @@
+from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
+from typing import Any, Union
+
+import pytest
+
+from spectree._pydantic import ValidationError
+from spectree._types import OptionalModelType
+from spectree.plugins.base import (
+    RawResponsePayload,
+    ResponseValidationResult,
+    validate_response,
+)
+from spectree.utils import gen_list_model
+from tests.common import JSON, Resp, RootResp, StrDict
+
+RespList = gen_list_model(Resp)
+
+
+@dataclass(frozen=True)
+class DummyResponse:
+    payload: bytes
+    content_type: str
+
+
+@pytest.mark.parametrize(
+    [
+        "skip_validation",
+        "validation_model",
+        "response_payload",
+        "expected_result",
+    ],
+    [
+        (
+            False,
+            Resp,
+            Resp(name="user1", score=[1, 2]),
+            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
+        ),
+        (
+            False,
+            Resp,
+            {"name": "user1", "score": [1, 2]},
+            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
+        ),
+        (
+            False,
+            Resp,
+            RawResponsePayload({"name": "user1", "score": [1, 2]}),
+            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
+        ),
+        (
+            False,
+            Resp,
+            {},
+            ValidationError,
+        ),
+        (
+            False,
+            Resp,
+            {"name": "user1"},
+            ValidationError,
+        ),
+        (
+            False,
+            RootResp,
+            [1, 2, 3],
+            ResponseValidationResult([1, 2, 3]),
+        ),
+        (
+            False,
+            RootResp,
+            RawResponsePayload([1, 2, 3]),
+            ResponseValidationResult([1, 2, 3]),
+        ),
+        (
+            False,
+            StrDict,
+            StrDict(__root__={"key1": "value1", "key2": "value2"}),
+            ResponseValidationResult({"key1": "value1", "key2": "value2"}),
+        ),
+        (
+            False,
+            RootResp,
+            {"name": "user2", "limit": 1},
+            ResponseValidationResult({"name": "user2", "limit": 1}),
+        ),
+        (
+            False,
+            RootResp,
+            RawResponsePayload({"name": "user2", "limit": 1}),
+            ResponseValidationResult({"name": "user2", "limit": 1}),
+        ),
+        (
+            False,
+            RootResp,
+            JSON(name="user3", limit=5),
+            ResponseValidationResult({"name": "user3", "limit": 5}),
+        ),
+        (
+            False,
+            RootResp,
+            RootResp(__root__=JSON(name="user4", limit=23)),
+            ResponseValidationResult({"name": "user4", "limit": 23}),
+        ),
+        (
+            False,
+            RootResp,
+            {},
+            ValidationError,
+        ),
+        (
+            False,
+            RespList,
+            [],
+            ResponseValidationResult([]),
+        ),
+        (
+            False,
+            RespList,
+            [{"name": "user5", "score": [5, 10]}],
+            ResponseValidationResult([{"name": "user5", "score": [5, 10]}]),
+        ),
+        (
+            False,
+            RespList,
+            [Resp(name="user6", score=[10, 20]), Resp(name="user7", score=[30, 40])],
+            ResponseValidationResult(
+                [
+                    {"name": "user6", "score": [10, 20]},
+                    {"name": "user7", "score": [30, 40]},
+                ]
+            ),
+        ),
+        (
+            False,
+            None,
+            {"user_id": "user1", "locale": "en-gb"},
+            ResponseValidationResult({"user_id": "user1", "locale": "en-gb"}),
+        ),
+        (
+            True,
+            None,
+            DummyResponse(payload="<html></html>".encode(), content_type="text/html"),
+            ResponseValidationResult(
+                DummyResponse(
+                    payload="<html></html>".encode(), content_type="text/html"
+                )
+            ),
+        ),
+    ],
+)
+def test_validate_response(
+    skip_validation: bool,
+    validation_model: OptionalModelType,
+    response_payload: Any,
+    expected_result: Union[ResponseValidationResult, ValidationError],
+):
+    runtime_expectation = (
+        pytest.raises(ValidationError)
+        if expected_result == ValidationError
+        else does_not_raise()
+    )
+    with runtime_expectation:
+        result = validate_response(
+            skip_validation=skip_validation,
+            validation_model=validation_model,
+            response_payload=response_payload,
+        )
+        assert isinstance(result, ResponseValidationResult)
+        assert result == expected_result

--- a/tests/test_plugin_falcon_asgi.py
+++ b/tests/test_plugin_falcon_asgi.py
@@ -2,7 +2,7 @@ from random import randint
 from typing import List
 
 import pytest
-from falcon import testing
+from falcon import HTTP_202, testing
 from falcon.asgi import App
 
 from spectree import Response, SpecTree
@@ -317,6 +317,7 @@ def test_client_and_api(request):
             description
             """
             resp.media = {"msg": "pong"}
+            resp.status = HTTP_202
 
     app = App()
     app.add_route("/ping", Ping())

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -43,16 +43,19 @@ def api_after_handler(req, resp, err, _):
 api = SpecTree("flask", before=before_handler, after=after_handler, annotations=True)
 app = Flask(__name__)
 app.config["TESTING"] = True
+app.config["DEBUG"] = True
 
 api_secure = SpecTree("flask", security_schemes=SECURITY_SCHEMAS)
 app_secure = Flask(__name__)
 app_secure.config["TESTING"] = True
+app_secure.config["DEBUG"] = True
 
 api_global_secure = SpecTree(
     "flask", security_schemes=SECURITY_SCHEMAS, security={"auth_apiKey": []}
 )
 app_global_secure = Flask(__name__)
 app_global_secure.config["TESTING"] = True
+app_global_secure.config["DEBUG"] = True
 
 
 @app.route("/ping")
@@ -219,6 +222,7 @@ def test_client_and_api(request):
     api = SpecTree(*api_args, **api_kwargs)
     app = Flask(__name__)
     app.config["TESTING"] = True
+    app.config["DEBUG"] = True
 
     @app.route("/ping")
     @api.validate(**endpoint_kwargs)

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -1,6 +1,7 @@
 from random import randint
 from typing import List
 
+import flask
 import pytest
 from flask import Blueprint, Flask, jsonify, request
 
@@ -18,6 +19,7 @@ from .common import (
     Resp,
     RootResp,
     StrDict,
+    UserXmlData,
     api_tag,
     get_paths,
     get_root_resp_data,
@@ -45,12 +47,12 @@ app = Blueprint("test_blueprint", __name__)
 
 
 @app.route("/ping")
-@api.validate(headers=Headers, resp=Response(HTTP_200=StrDict), tags=["test", "health"])
+@api.validate(headers=Headers, resp=Response(HTTP_202=StrDict), tags=["test", "health"])
 def ping():
     """summary
 
     description"""
-    return jsonify(msg="pong")
+    return jsonify(msg="pong"), 202
 
 
 @app.route("/api/file_upload", methods=["POST"])
@@ -108,11 +110,19 @@ def user_score_annotated(name, query: Query, json: JSON, cookies: Cookies, form:
     skip_validation=True,
 )
 def user_score_skip_validation(name):
+    response_format = request.args.get("response_format")
+    assert response_format in ("json", "xml")
     score = [randint(0, request.context.json.limit) for _ in range(5)]
     score.sort(reverse=True if request.context.query.order == Order.desc else False)
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
-    return jsonify(name=request.context.json.name, x_score=score)
+    if response_format == "json":
+        return jsonify(name=request.context.json.name, x_score=score)
+    else:
+        return flask.Response(
+            UserXmlData(name=request.context.json.name, score=score).dump_xml(),
+            content_type="text/xml",
+        )
 
 
 @app.route("/api/user_model/<name>", methods=["POST"])
@@ -205,7 +215,7 @@ def test_blueprint_prefix(client, prefix):
     assert resp.headers.get("X-Error") == "Validation Error"
 
     resp = client.get(prefix + "/ping", headers={"lang": "en-US"})
-    assert resp.status_code == 200
+    assert resp.status_code == 202
     assert resp.json == {"msg": "pong"}
     assert resp.headers.get("X-Error") is None
     assert resp.headers.get("X-Validation") == "Pass"

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -180,6 +180,8 @@ def return_root():
 api.register(app)
 
 flask_app = Flask(__name__)
+flask_app.config["DEBUG"] = True
+flask_app.config["TESTING"] = True
 flask_app.register_blueprint(app)
 with flask_app.app_context():
     api.spec


### PR DESCRIPTION
As promised, this is a followup [this PR](https://github.com/0b01001001/spectree/pull/338) which unifies and simplifies response validation across plugins. Response validation has been generalised in a single/simple function used across plugins.