### PR TITLE
Fix Flask status code processing after release 1.2.2

### DIFF
--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -207,7 +207,7 @@ class FlaskPlugin(BasePlugin):
             else:
                 response_payload = result[0]
         else:
-            response_payload = result
+            response_payload, status = result, result.status_code
 
         try:
             response_validation_result = validate_response(

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -206,8 +206,10 @@ class FlaskPlugin(BasePlugin):
                 response_payload, status, *rest = result
             else:
                 response_payload = result[0]
-        else:
+        elif isinstance(result, flask.Response):
             response_payload, status = result, result.status_code
+        else:
+            response_payload = result
 
         try:
             response_validation_result = validate_response(

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -368,6 +368,96 @@
         "tags": []
       }
     },
+    "/api/return_make_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_make_response",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_make_response_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_return_make_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_make_response_post <POST>",
+        "tags": []
+      }
+    },
     "/api/return_root": {
       "get": {
         "description": "",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -368,6 +368,96 @@
         "tags": []
       }
     },
+    "/api/return_make_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_make_response",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_make_response_get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_return_make_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "return_make_response_post <POST>",
+        "tags": []
+      }
+    },
     "/api/return_root": {
       "get": {
         "description": "",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -373,6 +373,96 @@
         "tags": []
       }
     },
+    "/api/return_make_response": {
+      "get": {
+        "description": "",
+        "operationId": "get__api_return_make_response",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__api_return_make_response",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JSON.7068f62"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resp.7068f62"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          }
+        },
+        "summary": "post <POST>",
+        "tags": []
+      }
+    },
     "/api/user/{name}": {
       "post": {
         "description": "",

--- a/tests/flask_imports/__init__.py
+++ b/tests/flask_imports/__init__.py
@@ -1,6 +1,8 @@
 from .dry_plugin_flask import (
     test_flask_doc,
     test_flask_list_json_request,
+    test_flask_make_response_get,
+    test_flask_make_response_post,
     test_flask_no_response,
     test_flask_return_list_request,
     test_flask_return_model,
@@ -20,4 +22,6 @@ __all__ = [
     "test_flask_upload_file",
     "test_flask_list_json_request",
     "test_flask_return_list_request",
+    "test_flask_make_response_post",
+    "test_flask_make_response_get",
 ]

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -1,8 +1,9 @@
 import io
+import random
 
 import pytest
 
-from tests.common import UserXmlData
+from tests.common import DemoModel, UserXmlData
 
 
 @pytest.mark.parametrize("response_format", ["json", "xml"])
@@ -179,6 +180,28 @@ def test_flask_return_list_request(client, pre_serialize: bool):
         {"name": "user1", "limit": 1},
         {"name": "user2", "limit": 2},
     ]
+
+
+def test_flask_make_response_post(client):
+    payload = DemoModel(
+        uid=random.randint(1, 10),
+        limit=random.randint(1, 10),
+        name="user make_response name",
+    )
+    resp = client.post(f"/api/return_make_response", json=payload.dict())
+    assert resp.status_code == 201
+    assert resp.json == {"name": payload.name, "score": [payload.uid]}
+
+
+def test_flask_make_response_get(client):
+    payload = DemoModel(
+        uid=random.randint(1, 10),
+        limit=random.randint(1, 10),
+        name="user make_response name",
+    )
+    resp = client.get(f"/api/return_make_response", query_string=payload.dict())
+    assert resp.status_code == 201
+    assert resp.json == {"name": payload.name, "score": [payload.uid]}
 
 
 @pytest.mark.parametrize("pre_serialize", [False, True])

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 
-from tests.common import DemoModel, UserXmlData
+from tests.common import JSON, UserXmlData
 
 
 @pytest.mark.parametrize("response_format", ["json", "xml"])
@@ -183,25 +183,23 @@ def test_flask_return_list_request(client, pre_serialize: bool):
 
 
 def test_flask_make_response_post(client):
-    payload = DemoModel(
-        uid=random.randint(1, 10),
+    payload = JSON(
         limit=random.randint(1, 10),
         name="user make_response name",
     )
     resp = client.post(f"/api/return_make_response", json=payload.dict())
     assert resp.status_code == 201
-    assert resp.json == {"name": payload.name, "score": [payload.uid]}
+    assert resp.json == {"name": payload.name, "score": [payload.limit]}
 
 
 def test_flask_make_response_get(client):
-    payload = DemoModel(
-        uid=random.randint(1, 10),
+    payload = JSON(
         limit=random.randint(1, 10),
         name="user make_response name",
     )
     resp = client.get(f"/api/return_make_response", query_string=payload.dict())
     assert resp.status_code == 201
-    assert resp.json == {"name": payload.name, "score": [payload.uid]}
+    assert resp.json == {"name": payload.name, "score": [payload.limit]}
 
 
 @pytest.mark.parametrize("pre_serialize", [False, True])

--- a/tests/flask_imports/dry_plugin_flask.py
+++ b/tests/flask_imports/dry_plugin_flask.py
@@ -187,7 +187,7 @@ def test_flask_make_response_post(client):
         limit=random.randint(1, 10),
         name="user make_response name",
     )
-    resp = client.post(f"/api/return_make_response", json=payload.dict())
+    resp = client.post("/api/return_make_response", json=payload.dict())
     assert resp.status_code == 201
     assert resp.json == {"name": payload.name, "score": [payload.limit]}
 
@@ -197,7 +197,7 @@ def test_flask_make_response_get(client):
         limit=random.randint(1, 10),
         name="user make_response name",
     )
-    resp = client.get(f"/api/return_make_response", query_string=payload.dict())
+    resp = client.get("/api/return_make_response", query_string=payload.dict())
     assert resp.status_code == 201
     assert resp.json == {"name": payload.name, "score": [payload.limit]}
 

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -2,7 +2,7 @@ from random import randint
 from typing import List
 
 import pytest
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, make_response, request
 
 from spectree import Response, SpecTree
 
@@ -10,6 +10,7 @@ from .common import (
     JSON,
     SECURITY_SCHEMAS,
     Cookies,
+    DemoModel,
     Form,
     FormFileUpload,
     Headers,
@@ -189,6 +190,26 @@ def return_list():
     pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
     data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
     return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+@app.route("/api/return_make_response", methods=["POST"])
+@api.validate(json=DemoModel, resp=Response(HTTP_201=Resp))
+def return_make_response_post():
+    model_data = DemoModel(**request.json)
+    response = make_response(
+        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+    )
+    return response
+
+
+@app.route("/api/return_make_response", methods=["GET"])
+@api.validate(query=DemoModel, resp=Response(HTTP_201=Resp))
+def return_make_response_get():
+    model_data = DemoModel(**request.args)
+    response = make_response(
+        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+    )
+    return response
 
 
 @app.route("/api/return_root", methods=["GET"])

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -10,7 +10,6 @@ from .common import (
     JSON,
     SECURITY_SCHEMAS,
     Cookies,
-    DemoModel,
     Form,
     FormFileUpload,
     Headers,
@@ -193,21 +192,21 @@ def return_list():
 
 
 @app.route("/api/return_make_response", methods=["POST"])
-@api.validate(json=DemoModel, resp=Response(HTTP_201=Resp))
+@api.validate(json=JSON, resp=Response(HTTP_201=Resp))
 def return_make_response_post():
-    model_data = DemoModel(**request.json)
+    model_data = JSON(**request.json)
     response = make_response(
-        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+        Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
     )
     return response
 
 
 @app.route("/api/return_make_response", methods=["GET"])
-@api.validate(query=DemoModel, resp=Response(HTTP_201=Resp))
+@api.validate(query=JSON, resp=Response(HTTP_201=Resp))
 def return_make_response_get():
-    model_data = DemoModel(**request.args)
+    model_data = JSON(**request.args)
     response = make_response(
-        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+        Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
     )
     return response
 

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -10,7 +10,6 @@ from spectree import Response, SpecTree
 from .common import (
     JSON,
     Cookies,
-    DemoModel,
     Form,
     FormFileUpload,
     Headers,
@@ -180,21 +179,21 @@ def return_list():
 
 
 @app.route("/api/return_make_response", methods=["POST"])
-@api.validate(json=DemoModel, resp=Response(HTTP_201=Resp))
+@api.validate(json=JSON, resp=Response(HTTP_201=Resp))
 def return_make_response_post():
-    model_data = DemoModel(**request.json)
+    model_data = JSON(**request.json)
     response = make_response(
-        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+        Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
     )
     return response
 
 
 @app.route("/api/return_make_response", methods=["GET"])
-@api.validate(query=DemoModel, resp=Response(HTTP_201=Resp))
+@api.validate(query=JSON, resp=Response(HTTP_201=Resp))
 def return_make_response_get():
-    model_data = DemoModel(**request.args)
+    model_data = JSON(**request.args)
     response = make_response(
-        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+        Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
     )
     return response
 

--- a/tests/test_plugin_flask_blueprint.py
+++ b/tests/test_plugin_flask_blueprint.py
@@ -3,13 +3,14 @@ from typing import List
 
 import flask
 import pytest
-from flask import Blueprint, Flask, jsonify, request
+from flask import Blueprint, Flask, jsonify, make_response, request
 
 from spectree import Response, SpecTree
 
 from .common import (
     JSON,
     Cookies,
+    DemoModel,
     Form,
     FormFileUpload,
     Headers,
@@ -176,6 +177,26 @@ def return_list():
     pre_serialize = bool(int(request.args.get("pre_serialize", default=0)))
     data = [JSON(name="user1", limit=1), JSON(name="user2", limit=2)]
     return [entry.dict() if pre_serialize else entry for entry in data]
+
+
+@app.route("/api/return_make_response", methods=["POST"])
+@api.validate(json=DemoModel, resp=Response(HTTP_201=Resp))
+def return_make_response_post():
+    model_data = DemoModel(**request.json)
+    response = make_response(
+        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+    )
+    return response
+
+
+@app.route("/api/return_make_response", methods=["GET"])
+@api.validate(query=DemoModel, resp=Response(HTTP_201=Resp))
+def return_make_response_get():
+    model_data = DemoModel(**request.args)
+    response = make_response(
+        Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+    )
+    return response
 
 
 @app.route("/api/return_root", methods=["GET"])

--- a/tests/test_plugin_flask_view.py
+++ b/tests/test_plugin_flask_view.py
@@ -10,7 +10,6 @@ from spectree import Response, SpecTree
 from .common import (
     JSON,
     Cookies,
-    DemoModel,
     Form,
     FormFileUpload,
     Headers,
@@ -193,24 +192,24 @@ class ReturnListView(MethodView):
 
 class ReturnMakeResponseView(MethodView):
     @api.validate(
-        json=DemoModel,
+        json=JSON,
         resp=Response(HTTP_201=Resp),
     )
     def post(self):
-        model_data = DemoModel(**request.json)
+        model_data = JSON(**request.json)
         response = make_response(
-            Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+            Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
         )
         return response
 
     @api.validate(
-        query=DemoModel,
+        query=JSON,
         resp=Response(HTTP_201=Resp),
     )
     def get(self):
-        model_data = DemoModel(**request.args)
+        model_data = JSON(**request.args)
         response = make_response(
-            Resp(name=model_data.name, score=[model_data.uid]).dict(), 201
+            Resp(name=model_data.name, score=[model_data.limit]).dict(), 201
         )
         return response
 


### PR DESCRIPTION
Following the release of version 1.2.2, the server response's status code generated through "make_response" is no longer being processed accurately. Instead, it is being overwritten with the status code 200.