### PR TITLE
feat: support pydantic v1 & v2 through Protocol

### DIFF
--- a/examples/falcon_asgi_demo.py
+++ b/examples/falcon_asgi_demo.py
@@ -15,6 +15,7 @@ spec = SpecTree(
     "falcon-asgi",
     title="Demo Service",
     version="0.1.2",
+    annotations=True,
 )
 
 demo = Tag(
@@ -75,18 +76,16 @@ class Classification:
         """
         resp.media = {"msg": f"hello from {source} to {target}"}
 
-    @spec.validate(
-        query=Query, json=Data, resp=Response(HTTP_200=Resp, HTTP_403=BadLuck)
-    )
-    async def on_post(self, req, resp, source, target):
+    @spec.validate(resp=Response(HTTP_200=Resp, HTTP_403=BadLuck))
+    async def on_post(self, req, resp, source, target, query: Query, json: Data):
         """
         post demo
 
-        demo for `query`, `data`, `resp`, `x`
+        demo for `query`, `data`, `resp`
         """
         logger.debug("%s => %s", source, target)
-        logger.info(req.context.query)
-        logger.info(req.context.json)
+        logger.info(query)
+        logger.info(json)
         if random() < 0.5:
             resp.status = falcon.HTTP_403
             resp.media = {"loc": "unknown", "msg": "bad luck", "typ": "random"}
@@ -99,8 +98,8 @@ class FileUpload:
     file-handling demo
     """
 
-    @spec.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
-    async def on_post(self, req, resp):
+    @spec.validate(resp=Response(HTTP_200=FileResp), tags=["file-upload"])
+    async def on_post(self, req, resp, form: File):
         """
         post multipart/form-data demo
 

--- a/examples/falcon_demo.py
+++ b/examples/falcon_demo.py
@@ -13,6 +13,7 @@ logger = logging.getLogger()
 
 spec = SpecTree(
     "falcon",
+    annotations=True,
     title="Demo Service",
     version="0.1.2",
     description="This is a demo service.",
@@ -79,18 +80,16 @@ class Classification:
         """
         resp.media = {"msg": f"hello from {source} to {target}"}
 
-    @spec.validate(
-        query=Query, json=Data, resp=Response(HTTP_200=Resp, HTTP_403=BadLuck)
-    )
-    def on_post(self, req, resp, source, target):
+    @spec.validate(resp=Response(HTTP_200=Resp, HTTP_403=BadLuck))
+    def on_post(self, req, resp, source, target, query: Query, json: Data):
         """
         post demo
 
-        demo for `query`, `data`, `resp`, `x`
+        demo for `query`, `data`, `resp`
         """
         logger.debug("%s => %s", source, target)
-        logger.info(req.context.query)
-        logger.info(req.context.json)
+        logger.info(query)
+        logger.info(json)
         if random() < 0.5:
             resp.status = falcon.HTTP_403
             resp.media = {"loc": "unknown", "msg": "bad luck", "typ": "random"}
@@ -103,14 +102,14 @@ class FileUpload:
     file-handling demo
     """
 
-    @spec.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
-    def on_post(self, req, resp):
+    @spec.validate(resp=Response(HTTP_200=FileResp), tags=["file-upload"])
+    def on_post(self, req, resp, form: File):
         """
         post multipart/form-data demo
 
         demo for 'form'
         """
-        file = req.context.form.file
+        file = form.file
         resp.media = {"filename": file.filename, "type": file.type}
 
 

--- a/examples/security_demo.py
+++ b/examples/security_demo.py
@@ -64,19 +64,14 @@ spec = SpecTree(
 
 
 @app.route("/ping", methods=["POST"])
-@spec.validate(
-    json=Req,
-)
-def ping():
+@spec.validate()
+def ping(json: Req):
     return "pong"
 
 
 @app.route("/ping/oauth", methods=["POST"])
-@spec.validate(
-    json=Req,
-    security=[{"auth_oauth2": ["read"]}],
-)
-def oauth_only():
+@spec.validate(security=[{"auth_oauth2": ["read"]}])
+def oauth_only(json: Req):
     return "pong"
 
 

--- a/examples/starlette_demo.py
+++ b/examples/starlette_demo.py
@@ -8,7 +8,7 @@ from starlette.routing import Mount, Route
 from examples.common import File, FileResp, Query
 from spectree import Response, SpecTree
 
-spec = SpecTree("starlette")
+spec = SpecTree("starlette", annotations=True)
 
 
 class Resp(BaseModel):
@@ -30,27 +30,27 @@ class Data(BaseModel):
     vip: bool
 
 
-@spec.validate(query=Query, json=Data, resp=Response(HTTP_200=Resp), tags=["api"])
-async def predict(request):
+@spec.validate(resp=Response(HTTP_200=Resp), tags=["api"])
+async def predict(request, query: Query, json: Data):
     """
     async api
 
     descriptions about this function
     """
     print(request.path_params)
-    print(request.context)
+    print(query, json)
     return JSONResponse({"label": 5, "score": 0.5})
     # return PydanticResponse(Resp(label=5, score=0.5))
 
 
-@spec.validate(form=File, resp=Response(HTTP_200=FileResp), tags=["file-upload"])
-async def file_upload(request):
+@spec.validate(resp=Response(HTTP_200=FileResp), tags=["file-upload"])
+async def file_upload(request, form: File):
     """
     post multipart/form-data demo
 
     demo for 'form'
     """
-    file = request.context.form.file
+    file = form.file
     return JSONResponse({"filename": file.filename, "type": file.type})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spectree"
-version = "1.3.0"
+version = "1.4.0"
 dynamic = []
 description = "generate OpenAPI document and validate request&response with Python annotations."
 readme = "README.md"

--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
@@ -33,6 +33,7 @@ if PYDANTIC2:
         root_validator,
         validator,
     )
+    from pydantic_core import core_schema  # noqa
 else:
     from pydantic import (  # type: ignore[no-redef,assignment]
         AnyUrl,
@@ -44,6 +45,80 @@ else:
         root_validator,
         validator,
     )
+
+
+@runtime_checkable
+class PydanticModelProtocol(Protocol):
+    def dict(
+        self,
+        *,
+        include=None,
+        exclude=None,
+        by_alias=False,
+        skip_defaults=None,
+        exclude_unset=False,
+        exclude_defaults=False,
+        exclude_none=False,
+    ):
+        pass
+
+    def json(
+        self,
+        *,
+        include=None,
+        exclude=None,
+        by_alias=False,
+        skip_defaults=None,
+        exclude_unset=False,
+        exclude_defaults=False,
+        exclude_none=False,
+        encoder=None,
+        models_as_dict=True,
+        **dumps_kwargs,
+    ):
+        pass
+
+    @classmethod
+    def parse_obj(cls, obj):
+        pass
+
+    @classmethod
+    def parse_raw(
+        cls, b, *, content_type=None, encoding="utf8", proto=None, allow_pickle=False
+    ):
+        pass
+
+    @classmethod
+    def parse_file(
+        cls, path, *, content_type=None, encoding="utf8", proto=None, allow_pickle=False
+    ):
+        pass
+
+    @classmethod
+    def construct(cls, _fields_set=None, **values):
+        pass
+
+    @classmethod
+    def copy(cls, *, include=None, exclude=None, update=None, deep=False):
+        pass
+
+    @classmethod
+    def schema(cls, by_alias=True, ref_template="#/definitions/{model}"):
+        pass
+
+    @classmethod
+    def schema_json(
+        cls, *, by_alias=True, ref_template="#/definitions/{model}", **dumps_kwargs
+    ):
+        pass
+
+    @classmethod
+    def validate(cls, value):
+        pass
+
+
+def is_pydantic_model(t: Any) -> bool:
+    return issubclass(t, PydanticModelProtocol)
 
 
 def is_base_model(t: Any) -> bool:

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -69,7 +69,7 @@ class Configuration(BaseSettings):
     #: OpenAPI file route path suffix (i.e. /apidoc/openapi.json)
     filename: str = "openapi.json"
     #: OpenAPI version (doesn't affect anything)
-    openapi_version: str = "3.0.3"
+    openapi_version: str = "3.1.0"
     #: the mode of the SpecTree validator :class:`ModeEnum`
     mode: ModeEnum = ModeEnum.normal
     #: A dictionary of documentation page templates. The key is the
@@ -79,7 +79,7 @@ class Configuration(BaseSettings):
     #: the rendered documentation page
     page_templates: Dict[str, str] = DEFAULT_PAGE_TEMPLATES
     #: opt-in type annotation feature, see the README examples
-    annotations: bool = False
+    annotations: bool = True
     #: servers section of OAS :py:class:`spectree.models.Server`
     servers: Optional[List[Server]] = []
     #: OpenAPI `securitySchemes` :py:class:`spectree.models.SecurityScheme`

--- a/spectree/models.py
+++ b/spectree/models.py
@@ -2,7 +2,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence, Set
 
-from ._pydantic import BaseModel, Field, root_validator, validator
+from ._pydantic import PYDANTIC2, BaseModel, Field, root_validator, validator
 
 # OpenAPI names validation regexp
 OpenAPI_NAME_RE = re.compile(r"^[A-Za-z0-9-._]+")
@@ -189,6 +189,19 @@ class BaseFile:
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
         field_schema.update(format="binary", type="string")
+
+    # pydantic v2
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _core_schema: Dict[str, Any], _handler):
+        return {"format": "binary", "type": "string"}
+
+    # pydantic v2
+    @classmethod
+    def __get_pydantic_core_schema__(cls, _source_type, _handler):
+        if PYDANTIC2:
+            from ._pydantic import core_schema
+
+            return core_schema.with_info_plain_validator_function(cls.validate)
 
     @classmethod
     def validate(cls, value: Any):

--- a/spectree/page.py
+++ b/spectree/page.py
@@ -10,6 +10,7 @@ DEFAULT_PAGE_TEMPLATES: Dict[str, str] = {
         <!-- needed for adaptive design -->
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%221em%22 font-size=%2280%22>📄</text></svg>">
         <link href=
         "https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
         rel="stylesheet">
@@ -39,14 +40,15 @@ DEFAULT_PAGE_TEMPLATES: Dict[str, str] = {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="SwaggerUI"/>
         <title>SwaggerUI</title>
-        <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
+        <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%221em%22 font-size=%2280%22>📄</text></svg>">
     </head>
 
     <body>
         <div id="swagger-ui"></div>
 
-        <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-bundle.js" crossorigin></script>
-        <script src="https://unpkg.com/swagger-ui-dist@5.0.0/swagger-ui-standalone-preset.js" crossorigin></script>
+        <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+        <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-standalone-preset.js" crossorigin></script>
         <script>
         window.onload = function() {{
         var full = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '');
@@ -54,17 +56,13 @@ DEFAULT_PAGE_TEMPLATES: Dict[str, str] = {
         const ui = SwaggerUIBundle({{
             url: "{spec_url}",
             dom_id: '#swagger-ui',
-            deepLinking: true,
             presets: [
-            SwaggerUIBundle.presets.apis,
-            SwaggerUIStandalonePreset
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
             ],
-            plugins: [
-            SwaggerUIBundle.plugins.DownloadUrl
-            ],
+            layout: "StandaloneLayout",
             oauth2RedirectUrl: full + "/{spec_path}/swagger/oauth2-redirect.html",
-            layout: "StandaloneLayout"
-        }})
+        }});
         ui.initOAuth({{
             clientId: "{client_id}",
             clientSecret: "{client_secret}",
@@ -73,11 +71,11 @@ DEFAULT_PAGE_TEMPLATES: Dict[str, str] = {
             scopeSeparator: "{scope_separator}",
             additionalQueryStringParams: {additional_query_string_params},
             useBasicAuthenticationWithAccessCodeGrant: {use_basic_authentication_with_access_code_grant},
-            usePkceWithAuthorizationCodeGrant: {use_pkce_with_authorization_code_grant}
-        }})
+            usePkceWithAuthorizationCodeGrant: {use_pkce_with_authorization_code_grant},
+        }});
         // End Swagger UI call region
 
-        window.ui = ui
+        window.ui = ui;
         }}
     </script>
     </body>
@@ -172,6 +170,7 @@ DEFAULT_PAGE_TEMPLATES: Dict[str, str] = {
         margin: 0;
       }}
     </style>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%221em%22 font-size=%2280%22>📄</text></svg>">
   </head>
   <body>
     <script

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -70,12 +70,11 @@ class FalconPlugin(BasePlugin):
         self.INT_ARGS_NAMES = ("num_digits", "min", "max")
 
     def register_route(self, app: Any):
-        self.app = app
-        self.app.add_route(
+        app.add_route(
             self.config.spec_url, self.OPEN_API_ROUTE_CLASS(self.spectree.spec)
         )
         for ui in self.config.page_templates:
-            self.app.add_route(
+            app.add_route(
                 f"/{self.config.path}/{ui}",
                 self.DOC_PAGE_ROUTE_CLASS(
                     self.config.page_templates[ui],
@@ -95,7 +94,7 @@ class FalconPlugin(BasePlugin):
             for child in node.children:
                 find_node(child)
 
-        for route in self.app._router._roots:
+        for route in self.spectree.app._router._roots:
             find_node(route)
 
         return routes

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -232,7 +232,7 @@ class QuartPlugin(BasePlugin):
             # no other status code
             if status == 200:
                 status = resp_status
-            additional_headers.append(resp_headers)
+            additional_headers.update(resp_headers)
 
         if not skip_validation and resp:
             try:

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -47,15 +47,13 @@ class StarlettePlugin(BasePlugin):
         self.conv2type = {conv: typ for typ, conv in CONVERTOR_TYPES.items()}
 
     def register_route(self, app):
-        self.app = app
-
-        self.app.add_route(
+        app.add_route(
             self.config.spec_url,
             lambda request: JSONResponse(self.spectree.spec),
         )
 
         for ui in self.config.page_templates:
-            self.app.add_route(
+            app.add_route(
                 f"/{self.config.path}/{ui}",
                 lambda request, ui=ui: HTMLResponse(
                     self.config.page_templates[ui].format(
@@ -201,7 +199,7 @@ class StarlettePlugin(BasePlugin):
                 else:
                     parse_route(route, prefix=f"{prefix}{route.path}")
 
-        parse_route(self.app)
+        parse_route(self.spectree.app)
         return routes
 
     def bypass(self, func, method):

--- a/spectree/response.py
+++ b/spectree/response.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-from ._pydantic import BaseModel
+from ._pydantic import is_pydantic_model
 from ._types import BaseModelSubclassType, ModelType, NamingStrategy, OptionalModelType
 from .utils import gen_list_model, get_model_key, parse_code
 
@@ -84,7 +84,9 @@ class Response:
                     list_item_type = model.__args__[0]  # type: ignore
                     model = gen_list_model(list_item_type)
                     self.code_list_item_types[code] = list_item_type
-                assert issubclass(model, BaseModel), "invalid `pydantic.BaseModel`"
+                assert is_pydantic_model(
+                    model
+                ), f"invalid `pydantic.BaseModel`: {model}"
                 assert description is None or isinstance(
                     description, str
                 ), "invalid HTTP status code description"

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -16,7 +16,7 @@ from typing import (
     Union,
 )
 
-from ._pydantic import BaseModel, ValidationError
+from ._pydantic import BaseModel, ValidationError, is_pydantic_model
 from ._types import (
     ModelType,
     MultiDict,
@@ -255,10 +255,9 @@ def get_model_schema(
     :param model: `pydantic.BaseModel` query, json, headers or cookies from
         request or response
     """
-    assert issubclass(model, BaseModel)
+    assert is_pydantic_model(model), f"{model} is not a pydantic model"
 
     nested_key = nested_naming_strategy(naming_strategy(model), "{model}")
-
     return model.schema(ref_template=f"#/components/schemas/{nested_key}")
 
 

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -264,7 +264,7 @@
     "title": "Service API Document",
     "version": "0.1.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/custom_serializer": {
       "get": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -298,7 +298,7 @@
     "title": "Service API Document",
     "version": "0.1.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/file_upload": {
       "post": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -298,7 +298,7 @@
     "title": "Service API Document",
     "version": "0.1.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/file_upload": {
       "post": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -298,7 +298,7 @@
     "title": "Service API Document",
     "version": "0.1.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/file_upload": {
       "post": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -264,7 +264,7 @@
     "title": "Service API Document",
     "version": "0.1.0"
   },
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "paths": {
     "/api/file_upload": {
       "post": {


### PR DESCRIPTION
## Changes

- set `annotations = True` by default
- upgrade swagger to v5 to support openapi v3.1.0
- use `typing.Protocol` to support both pydantic v1 & v2

## Fix
- close #382