### PR TITLE
Maintain pydantic.v1 model compatibility while using pydantic v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spectree"
-version = "1.4.1"
+version = "1.4.2"
 dynamic = []
 description = "generate OpenAPI document and validate request&response with Python annotations."
 readme = "README.md"

--- a/spectree/config.py
+++ b/spectree/config.py
@@ -40,6 +40,7 @@ class License(InternalBaseModel):
 
 class Configuration(InternalBaseModel):
     """Global configuration."""
+
     # OpenAPI configurations
     #: title of the service
     title: str = "Service API Document"

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, get_type_hints
 from falcon import HTTP_400, HTTP_415, HTTPError
 from falcon.routing.compiled import _FIELD_PATTERN as FALCON_FIELD_PATTERN
 
-from spectree._pydantic import ValidationError
+from spectree._pydantic import InternalValidationError, ValidationError
 from spectree._types import ModelType
 from spectree.plugins.base import BasePlugin, validate_response
 from spectree.response import Response
@@ -211,7 +211,7 @@ class FalconPlugin(BasePlugin):
             try:
                 self.request_validation(_req, query, json, form, headers, cookies)
 
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
                 _resp.status = f"{validation_error_status} Validation Error"
                 _resp.media = err.errors()
@@ -235,7 +235,7 @@ class FalconPlugin(BasePlugin):
                     validation_model=resp.find_model(status),
                     response_payload=_resp.media,
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 resp_validation_error = err
                 _resp.status = HTTP_500
                 _resp.media = err.errors()
@@ -317,7 +317,7 @@ class FalconAsgiPlugin(FalconPlugin):
             try:
                 await self.request_validation(_req, query, json, form, headers, cookies)
 
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
                 _resp.status = f"{validation_error_status} Validation Error"
                 _resp.media = err.errors()
@@ -345,7 +345,7 @@ class FalconAsgiPlugin(FalconPlugin):
                     validation_model=resp.find_model(status) if resp else None,
                     response_payload=_resp.media,
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 resp_validation_error = err
                 _resp.status = HTTP_500
                 _resp.media = err.errors()

--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -4,7 +4,7 @@ import flask
 from flask import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from spectree._pydantic import ValidationError
+from spectree._pydantic import InternalValidationError, ValidationError
 from spectree._types import ModelType
 from spectree.plugins.base import BasePlugin, Context, validate_response
 from spectree.response import Response
@@ -185,7 +185,7 @@ class FlaskPlugin(BasePlugin):
         if not skip_validation:
             try:
                 self.request_validation(request, query, json, form, headers, cookies)
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
                 response = make_response(jsonify(err.errors()), validation_error_status)
 
@@ -223,7 +223,7 @@ class FlaskPlugin(BasePlugin):
                     validation_model=resp.find_model(status),
                     response_payload=payload,
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 response = make_response(err.errors(), 500)
                 resp_validation_error = err
             else:

--- a/spectree/plugins/quart_plugin.py
+++ b/spectree/plugins/quart_plugin.py
@@ -5,7 +5,7 @@ import quart
 from quart import Blueprint, abort, current_app, jsonify, make_response, request
 from werkzeug.routing import parse_converter_args
 
-from spectree._pydantic import ValidationError
+from spectree._pydantic import InternalValidationError, ValidationError
 from spectree._types import ModelType
 from spectree.plugins.base import BasePlugin, Context, validate_response
 from spectree.response import Response
@@ -195,7 +195,7 @@ class QuartPlugin(BasePlugin):
                 await self.request_validation(
                     request, query, json, form, headers, cookies
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
                 response = await make_response(
                     jsonify(err.errors()), validation_error_status
@@ -240,7 +240,7 @@ class QuartPlugin(BasePlugin):
                     validation_model=resp.find_model(status),
                     response_payload=payload,
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 response = await make_response(err.errors(), 500)
                 resp_validation_error = err
             else:

--- a/spectree/plugins/starlette_plugin.py
+++ b/spectree/plugins/starlette_plugin.py
@@ -10,6 +10,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import compile_path
 
 from spectree._pydantic import (
+    InternalValidationError,
     ValidationError,
     generate_root_model,
     serialize_model_instance,
@@ -114,7 +115,7 @@ class StarlettePlugin(BasePlugin):
                 await self.request_validation(
                     request, query, json, form, headers, cookies
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
                 response = JSONResponse(err.errors(), validation_error_status)
             except JSONDecodeError as err:
@@ -160,7 +161,7 @@ class StarlettePlugin(BasePlugin):
                     validation_model=resp.find_model(response.status_code),
                     response_payload=RawResponsePayload(payload=response.body),
                 )
-            except ValidationError as err:
+            except (InternalValidationError, ValidationError) as err:
                 response = JSONResponse(err.errors(), 500)
                 resp_validation_error = err
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -260,22 +260,22 @@ class CompatibilityView:
     name = "validation works for both pydantic v1 and v2 models simultaneously"
 
     class V1(InternalBaseModel):
-        value: str
+        value: int
 
     class V2(BaseModel):
-        value: str
+        value: int
 
     @api.validate(
         resp=Response(HTTP_200=Resp),
     )
     def on_post_v1(self, req, resp, json: V1):
-        resp.media = "V1"
+        resp.media = Resp(name="falcon v1", score=[1, 2, 3])
 
     @api.validate(
         resp=Response(HTTP_200=Resp),
     )
     def on_post_v2(self, req, resp, json: V2):
-        resp.media = "V2"
+        resp.media = Resp(name="falcon v2", score=[1, 2, 3])
 
 
 app = App()
@@ -579,11 +579,11 @@ def test_falcon_optional_alias_response(client):
 @pytest.mark.skipif(not PYDANTIC2, reason="only matters if using both model types")
 def test_falcon_validate_both_v1_and_v2_validation_errors(client):
     resp = client.simulate_request(
-        "POST", "/api/compatibility/v1", json={"value": id(object())}
+        "POST", "/api/compatibility/v1", json={"value": "invalid"}
     )
     assert resp.status_code == 422
 
     resp = client.simulate_request(
-        "POST", "/api/compatibility/v2", json={"value": id(object())}
+        "POST", "/api/compatibility/v2", json={"value": "invalid"}
     )
     assert resp.status_code == 422

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -256,26 +256,6 @@ class ViewWithCustomSerializer:
         resp.text = Resp(name="falcon", score=[1, 2, 3]).json()
 
 
-class CompatibilityView:
-    name = "validation works for both pydantic v1 and v2 models simultaneously"
-
-    class V1(InternalBaseModel):
-        value: int
-
-    class V2(BaseModel):
-        value: int
-
-    @api.validate(
-        resp=Response(HTTP_200=Resp),
-    )
-    def on_post_v1(self, req, resp, json: V1):
-        resp.media = Resp(name="falcon v1", score=[1, 2, 3])
-
-    @api.validate(
-        resp=Response(HTTP_200=Resp),
-    )
-    def on_post_v2(self, req, resp, json: V2):
-        resp.media = Resp(name="falcon v2", score=[1, 2, 3])
 
 
 app = App()
@@ -292,8 +272,6 @@ app.add_route("/api/return_list", ReturnListView())
 app.add_route("/api/return_root", ReturnRootView())
 app.add_route("/api/return_optional_alias", ReturnOptionalAliasView())
 app.add_route("/api/custom_serializer", ViewWithCustomSerializer())
-app.add_route("/api/compatibility/v1", CompatibilityView(), suffix="v1")
-app.add_route("/api/compatibility/v2", CompatibilityView(), suffix="v2")
 api.register(app)
 
 
@@ -578,6 +556,31 @@ def test_falcon_optional_alias_response(client):
 
 @pytest.mark.skipif(not PYDANTIC2, reason="only matters if using both model types")
 def test_falcon_validate_both_v1_and_v2_validation_errors(client):
+
+    class CompatibilityView:
+        name = "validation works for both pydantic v1 and v2 models simultaneously"
+
+        class V1(InternalBaseModel):
+            value: int
+
+        class V2(BaseModel):
+            value: int
+
+        @api.validate(
+            resp=Response(HTTP_200=Resp),
+        )
+        def on_post_v1(self, req, resp, json: V1):
+            resp.media = Resp(name="falcon v1", score=[1, 2, 3])
+
+        @api.validate(
+            resp=Response(HTTP_200=Resp),
+        )
+        def on_post_v2(self, req, resp, json: V2):
+            resp.media = Resp(name="falcon v2", score=[1, 2, 3])
+
+    app.add_route("/api/compatibility/v1", CompatibilityView(), suffix="v1")
+    app.add_route("/api/compatibility/v2", CompatibilityView(), suffix="v2")
+
     resp = client.simulate_request(
         "POST", "/api/compatibility/v1", json={"value": "invalid"}
     )

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -256,8 +256,6 @@ class ViewWithCustomSerializer:
         resp.text = Resp(name="falcon", score=[1, 2, 3]).json()
 
 
-
-
 app = App()
 app.add_route("/ping", Ping())
 app.add_route("/api/user/{name}", UserScore())
@@ -556,7 +554,6 @@ def test_falcon_optional_alias_response(client):
 
 @pytest.mark.skipif(not PYDANTIC2, reason="only matters if using both model types")
 def test_falcon_validate_both_v1_and_v2_validation_errors(client):
-
     class CompatibilityView:
         name = "validation works for both pydantic v1 and v2 models simultaneously"
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -269,13 +269,13 @@ class CompatibilityView:
         resp=Response(HTTP_200=Resp),
     )
     def on_post_v1(self, req, resp, json: V1):
-        resp.media = 'V1'
+        resp.media = "V1"
 
     @api.validate(
         resp=Response(HTTP_200=Resp),
     )
     def on_post_v2(self, req, resp, json: V2):
-        resp.media = 'V2'
+        resp.media = "V2"
 
 
 app = App()
@@ -292,8 +292,8 @@ app.add_route("/api/return_list", ReturnListView())
 app.add_route("/api/return_root", ReturnRootView())
 app.add_route("/api/return_optional_alias", ReturnOptionalAliasView())
 app.add_route("/api/custom_serializer", ViewWithCustomSerializer())
-app.add_route("/api/compatibility/v1", CompatibilityView(), suffix='v1')
-app.add_route("/api/compatibility/v2", CompatibilityView(), suffix='v2')
+app.add_route("/api/compatibility/v1", CompatibilityView(), suffix="v1")
+app.add_route("/api/compatibility/v2", CompatibilityView(), suffix="v2")
 api.register(app)
 
 
@@ -579,12 +579,11 @@ def test_falcon_optional_alias_response(client):
 @pytest.mark.skipif(not PYDANTIC2, reason="only matters if using both model types")
 def test_falcon_validate_both_v1_and_v2_validation_errors(client):
     resp = client.simulate_request(
-            "POST", "/api/compatibility/v1", json={"value": id(object())}
-     )
+        "POST", "/api/compatibility/v1", json={"value": id(object())}
+    )
     assert resp.status_code == 422
 
     resp = client.simulate_request(
-            "POST", "/api/compatibility/v2", json={"value": id(object())}
-     )
+        "POST", "/api/compatibility/v2", json={"value": id(object())}
+    )
     assert resp.status_code == 422
-


### PR DESCRIPTION
We have pydantic V2 installed in our environemnt, but have been using `from pydantic.v1 import ...`.  With the new changes to support pydantic V2 we are wanting to upgrade Spectree to latest and begin writing new serializers, however, we are not ready to update all of our current models to  be pydantic v2 BaseModels.

Currently if a `ValidationError` is raised, the falcon plug in does not catch it, since `ValidationError` in the plugin is coming from `pydantic`, not `pydantic.v1`.

Since you are aliasing the `pydantic.v1.ValidationError as InternalValidationError`, catching it as well allows us to continue to support our v1 models while we migrate to v2 models.

Looking at the codebase, this looks like a similar issue in the other plugins.  Let me know if you would like me to submit this update for them as well.  I'm not sure where you would like a test for this in the project.
