### PR TITLE
Migrate deprecated Pydantic function

### DIFF
--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -265,7 +265,7 @@ def get_model_schema(
     assert is_pydantic_model(model), f"{model} is not a pydantic model"
 
     nested_key = nested_naming_strategy(naming_strategy(model), "{model}")
-    return model.schema(ref_template=f"#/components/schemas/{nested_key}")
+    return model.model_json_schema(ref_template=f"#/components/schemas/{nested_key}")
 
 
 def get_security(security: Union[None, Mapping, Sequence[Any]]) -> List[Any]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -237,7 +237,7 @@ def test_parse_params():
     models = {
         get_model_path_key(
             f"{DemoModel.__module__}.{DemoModel.__name__}"
-        ): DemoModel.schema(ref_template="#/components/schemas/{model}")
+        ): DemoModel.model_json_schema(ref_template="#/components/schemas/{model}")
     }
     assert parse_params(demo_func, [], models) == []
     params = parse_params(demo_class.demo_method, [], models)
@@ -254,7 +254,7 @@ def test_parse_params():
 
 def test_parse_params_with_route_param_keywords():
     models = {
-        get_model_path_key("tests.common.DemoQuery"): DemoQuery.schema(
+        get_model_path_key("tests.common.DemoQuery"): DemoQuery.model_json_schema(
             ref_template="#/components/schemas/{model}"
         )
     }


### PR DESCRIPTION
Pydantic's `.schema()` function is deprecated. This throws warnings and will eventually break when Pydantic v3.0 is used with Spectree.

This PR fixes this issue.

Thanks!