### PR TITLE
Fix Flask crashes after Pydantic V2 validator raises ValueError + compatibility issue in default_after_handler

### DIFF
--- a/spectree/plugins/flask_plugin.py
+++ b/spectree/plugins/flask_plugin.py
@@ -187,7 +187,8 @@ class FlaskPlugin(BasePlugin):
                 self.request_validation(request, query, json, form, headers, cookies)
             except (InternalValidationError, ValidationError) as err:
                 req_validation_error = err
-                response = make_response(jsonify(err.errors()), validation_error_status)
+                errors = err.errors() if isinstance(err, InternalValidationError) else err.errors(include_context=False)
+                response = make_response(jsonify(errors), validation_error_status)
 
         if self.config.annotations:
             annotations = get_type_hints(func)
@@ -224,7 +225,8 @@ class FlaskPlugin(BasePlugin):
                     response_payload=payload,
                 )
             except (InternalValidationError, ValidationError) as err:
-                response = make_response(err.errors(), 500)
+                errors = err.errors() if isinstance(err, InternalValidationError) else err.errors(include_context=False)
+                response = make_response(errors, 500)
                 resp_validation_error = err
             else:
                 response = make_response(

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -211,7 +211,8 @@ def default_after_handler(
     if resp_validation_error:
         logger.error(
             "500 Response Validation Error: %s - %s",
-            resp_validation_error.model.__name__,
+            getattr(resp_validation_error, "title", None)
+            or resp_validation_error.model.__name__,
             resp_validation_error.errors(),
         )
 


### PR DESCRIPTION
Fix [issue #396](https://github.com/0b01001001/spectree/issues/396)

1. In Pydantic V2 ValidationError, don't include_context which adds the original exception which might not be serializable
2. Follow the lead of `default_before_handler`, and adapt `default_after_handler` to Pydantic V2 ValidationError