### PR TITLE
fix: conversion to dictionary depending on pydantic version

### DIFF
--- a/spectree/_pydantic.py
+++ b/spectree/_pydantic.py
@@ -192,7 +192,11 @@ def serialize_model_instance(value: BaseModel):
     """Serialize a Pydantic BaseModel (equivalent of calling `.dict()` on a BaseModel,
     but additionally takes care of stripping __root__ for root models.
     """
-    serialized = value.dict()
+    if PYDANTIC2: # noqa: SIM108
+        serialized = value.model_dump()
+    else:
+        serialized = value.dict()
+
     if is_root_model_instance(value) and ROOT_FIELD in serialized:
         return serialized[ROOT_FIELD]
     return serialized


### PR DESCRIPTION
hi!

having pydantic v2 I wouldn't want to call the `dict` method for at least two reasons:
1. its **deprecated** for v2
2. I could have an overridden implementation of the `dict` method and after moving to v2 it would be logical to **rename** it to `model_dump`. Without this change I'll have to debug the spectree code before I understood that my **method with the new name won't be called**

---

p.s. `noqa: SIM108` it's a matter of taste, I can change it to a ternary operator as the linter suggests, if you want that too