### PR TITLE
feat: set required field on requestBody according to OpenAPI spec

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -309,7 +309,7 @@ class SpecTree:
                 for tag in func_tags:
                     if str(tag) not in tags:
                         tags[str(tag)] = (
-                            tag.dict() if isinstance(tag, Tag) else {"name": tag}
+                            tag.dict(exclude_none=True) if isinstance(tag, Tag) else {"name": tag}
                         )
 
                 routes[path][method.lower()] = {

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -108,7 +108,7 @@ def parse_request(func: Any) -> Dict[str, Any]:
     if not content_items:
         return {}
 
-    return {"content": content_items}
+    return {"content": content_items, "required": True}
 
 
 def parse_params(

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -192,7 +192,8 @@
                 "$ref": "#/components/schemas/CustomError.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -292,7 +293,8 @@
                 "$ref": "#/components/schemas/FormFileUpload.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "on_post <POST>",
@@ -311,7 +313,8 @@
                 "$ref": "#/components/schemas/ListJSON.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "on_post <POST>",
@@ -352,7 +355,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "on_post <POST>",
@@ -532,7 +536,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -684,7 +689,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -798,7 +804,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -912,7 +919,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -226,7 +226,8 @@
                 "$ref": "#/components/schemas/CustomError.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -266,7 +267,8 @@
                 "$ref": "#/components/schemas/FormFileUpload.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "file_upload <POST>",
@@ -285,7 +287,8 @@
                 "$ref": "#/components/schemas/ListJSON.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "json_list <POST>",
@@ -304,7 +307,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "no_response <GET>",
@@ -321,7 +325,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "no_response <POST>",
@@ -464,7 +469,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -631,7 +637,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -749,7 +756,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -824,7 +832,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -899,7 +908,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -226,7 +226,8 @@
                 "$ref": "#/components/schemas/CustomError.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -266,7 +267,8 @@
                 "$ref": "#/components/schemas/FormFileUpload.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "file_upload <POST>",
@@ -285,7 +287,8 @@
                 "$ref": "#/components/schemas/ListJSON.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "list_json <POST>",
@@ -304,7 +307,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "no_response <GET>",
@@ -321,7 +325,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "no_response <POST>",
@@ -464,7 +469,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -631,7 +637,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -749,7 +756,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -824,7 +832,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -899,7 +908,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -226,7 +226,8 @@
                 "$ref": "#/components/schemas/CustomError.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -266,7 +267,8 @@
                 "$ref": "#/components/schemas/FormFileUpload.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "post <POST>",
@@ -285,7 +287,8 @@
                 "$ref": "#/components/schemas/ListJSON.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "post <POST>",
@@ -326,7 +329,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "post <POST>",
@@ -469,7 +473,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
@@ -605,7 +610,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -723,7 +729,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -803,7 +810,8 @@
                 "$ref": "#/components/schemas/Form.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -878,7 +886,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -192,7 +192,8 @@
                 "$ref": "#/components/schemas/CustomError.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -232,7 +233,8 @@
                 "$ref": "#/components/schemas/FormFileUpload.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "file_upload <POST>",
@@ -251,7 +253,8 @@
                 "$ref": "#/components/schemas/ListJSON.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {},
         "summary": "list_json <POST>",
@@ -270,7 +273,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -301,7 +305,8 @@
                 "$ref": "#/components/schemas/StrDict.a9993e3"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -456,7 +461,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -569,7 +575,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -644,7 +651,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -719,7 +727,8 @@
                 "$ref": "#/components/schemas/JSON.7068f62"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {


### PR DESCRIPTION
According to [OpenApi spec](https://swagger.io/docs/specification/v3_0/describing-request-body/describing-request-body/):

> Request bodies are optional by default.

## Current behaviour

```py
@spec.validate()
def post(json: Book):
  ...
```

```json
{
    "post": {
        "requestBody": {
            "content": {
                "application/json": {
                    "schema": {
                        "$ref": "#/components/schemas/Book"
                    }
                }
            }
        }
    }
}
```

Since `required` is not set, request body is treated as optional.

## Desired behaviour

Label request body as `required`, to match endpoint definition.

```json
{
    "post": {
        "requestBody": {
            "content": {
                "application/json": {
                    "schema": {
                        "$ref": "#/components/schemas/Book"
                    }
                }
            },
            "required": true
        }
    }
}
```