### PR TITLE
fix: keep the falcon file stream in memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spectree"
-version = "1.5.2"
+version = "1.5.3"
 dynamic = []
 description = "Generate OpenAPI document and validate request & response with Python annotations."
 readme = "README.md"

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -215,15 +215,13 @@ class FalconPlugin(BasePlugin):
         if cookies:
             req.context.cookies = cookies.parse_obj(req.cookies)
         if json:
-            media = req.media
-            req.context.json = json.parse_obj(media)
+            req.context.json = json.parse_obj(req.get_media())
         if form and req.content_type:
-            form_data = req.get_media()
+            req_form = {}
             if req.content_type == "application/x-www-form-urlencoded":
-                req_form = form_data
+                req_form = req.get_media()
             elif req.content_type.startswith("multipart/form-data"):
-                req_form = {}
-                for part in form_data:
+                for part in req.get_media():
                     if part.filename is None:
                         req_form[part.name] = part.get_data()
                     else:
@@ -354,12 +352,11 @@ class FalconAsgiPlugin(FalconPlugin):
             media = await req.get_media()
             req.context.json = json.parse_obj(media)
         if form and req.content_type:
-            form_data = await req.get_media()
+            req_form = {}
             if req.content_type == "application/x-www-form-urlencoded":
-                req_form = form_data
+                req_form = await req.get_media()
             elif req.content_type.startswith("multipart/form-data"):
-                req_form = {}
-                async for part in form_data:
+                async for part in await req.get_media():
                     if part.filename is None:
                         req_form[part.name] = await part.get_data()
                     else:

--- a/spectree/plugins/falcon_plugin.py
+++ b/spectree/plugins/falcon_plugin.py
@@ -27,7 +27,7 @@ class StreamWrapper:
     def __init__(self, stream):
         self._buf = BytesIO(stream)
 
-    def read(self, size: int | None = -1, /) -> bytes:
+    def read(self, size: Optional[int] = -1, /) -> bytes:
         return self._buf.read(size)
 
     def exhaust(self) -> None:
@@ -36,7 +36,7 @@ class StreamWrapper:
 
 
 class AsyncStreamWrapper(StreamWrapper):
-    async def read(self, size: int | None = -1, /) -> bytes:  # type: ignore[override]
+    async def read(self, size: Optional[int] = -1, /) -> bytes:  # type: ignore[override]
         return super().read(size)
 
     async def exhaust(self) -> None:  # type: ignore[override]

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[falcon][full_spec].json
@@ -39,6 +39,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "File"
           },
           "other": {
@@ -47,7 +48,6 @@
           }
         },
         "required": [
-          "file",
           "other"
         ],
         "title": "FormFileUpload",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask][full_spec].json
@@ -57,6 +57,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "File"
           },
           "other": {
@@ -65,7 +66,6 @@
           }
         },
         "required": [
-          "file",
           "other"
         ],
         "title": "FormFileUpload",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_blueprint][full_spec].json
@@ -57,6 +57,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "File"
           },
           "other": {
@@ -65,7 +66,6 @@
           }
         },
         "required": [
-          "file",
           "other"
         ],
         "title": "FormFileUpload",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[flask_view][full_spec].json
@@ -57,6 +57,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "File"
           },
           "other": {
@@ -65,7 +66,6 @@
           }
         },
         "required": [
-          "file",
           "other"
         ],
         "title": "FormFileUpload",

--- a/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
+++ b/tests/__snapshots__/test_plugin/test_plugin_spec[starlette][full_spec].json
@@ -39,6 +39,7 @@
                 "type": "null"
               }
             ],
+            "default": null,
             "title": "File"
           },
           "other": {
@@ -47,7 +48,6 @@
           }
         },
         "required": [
-          "file",
           "other"
         ],
         "title": "FormFileUpload",

--- a/tests/common.py
+++ b/tests/common.py
@@ -38,7 +38,7 @@ class QueryList(BaseModel):
 
 
 class FormFileUpload(BaseModel):
-    file: Optional[BaseFile]
+    file: Optional[BaseFile] = None
     other: str
 
 

--- a/tests/test_plugin_falcon.py
+++ b/tests/test_plugin_falcon.py
@@ -201,9 +201,11 @@ class FileUploadView:
         form=FormFileUpload,
     )
     def on_post(self, req, resp, form: FormFileUpload):
-        assert form.file
-        file_content = form.file.data
-        resp.media = {"file": file_content.decode("utf-8"), "other": form.other}
+        if form.file:
+            file_content = form.file.stream.read()
+            resp.media = {"file": file_content.decode("utf-8"), "other": form.other}
+        else:
+            resp.media = {"file": None, "other": form.other}
 
 
 class ListJsonView:
@@ -569,6 +571,16 @@ def test_falcon_file_upload_sync(client):
     assert resp.status_code == 200, resp.text
     assert resp.headers["content-type"] == "application/json"
     assert resp.json["file"] == file_content
+    assert resp.json["other"] == "test"
+
+    resp = client.simulate_post(
+        "/api/file_upload",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body="other=test".encode("utf-8"),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/json"
+    assert resp.json["file"] is None
     assert resp.json["other"] == "test"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1100,7 +1100,7 @@ wheels = [
 
 [[package]]
 name = "spectree"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Address the comments from https://github.com/0b01001001/spectree/pull/434/files#r2293604269

1. remove the try...except, it seems those exceptions are not meant to be caught in this layer
2. replace `data` with `get_data()`
3. test both `application/x-www-form-urlencoded` & `multipart/form-data`
4. wrap the stream (this is a bad idea for large files)

It seems the falcon internal stream only lives in the `request.get_media().__iter__`. After that, it will be empty. But we have to go through the `__iter__` here.

Not sure if there are any better ways.