### PR TITLE
refactor: use dataclass as the source for adapter

### DIFF
--- a/spectree/model_adapter/msgspec_adapter.py
+++ b/spectree/model_adapter/msgspec_adapter.py
@@ -89,7 +89,7 @@ class MsgspecModelAdapter(ModelAdapter[Any, msgspec.ValidationError, BaseFile]):
         self,
         root_type: type[Any],
         *,
-        name: str = "GeneratedRootModel",
+        name: str | None = None,
         module: str | None = None,
     ) -> type[msgspec.Struct]:
         """
@@ -97,7 +97,8 @@ class MsgspecModelAdapter(ModelAdapter[Any, msgspec.ValidationError, BaseFile]):
 
         See: https://github.com/jcrist/msgspec/issues/484
         """
-        T = Annotated[root_type, msgspec.Meta(title=name)]  # type: ignore
+        model_name = name or "GeneratedRootModel"
+        T = Annotated[root_type, msgspec.Meta(title=model_name)]  # type: ignore
         return T  # type: ignore
 
     def make_list_model(self, model: type) -> type:

--- a/spectree/model_adapter/protocol.py
+++ b/spectree/model_adapter/protocol.py
@@ -43,7 +43,7 @@ class ModelAdapter(Protocol[ModelT, ValidationErrorT, BaseFileT]):
         self,
         root_type: Any,
         *,
-        name: str = "GeneratedRootModel",
+        name: str | None = None,
         module: str | None = None,
     ) -> ModelClass: ...
 

--- a/spectree/model_adapter/pydantic_adapter.py
+++ b/spectree/model_adapter/pydantic_adapter.py
@@ -95,11 +95,12 @@ class PydanticModelAdapter(ModelAdapter[Any, ValidationError, type[BaseFile]]):
         self,
         root_type: Any,
         *,
-        name: str = "GeneratedRootModel",
+        name: str | None = None,
         module: str | None = None,
     ) -> type[BaseModel]:
+        model_name = name or "GeneratedRootModel"
         module_name = module or __name__
-        return type(name, (RootModel[root_type],), {"__module__": module_name})
+        return type(model_name, (RootModel[root_type],), {"__module__": module_name})
 
     def make_list_model(self, model: type[Any]) -> type[BaseModel]:
         return self.make_root_model(

--- a/tests/model_cases.py
+++ b/tests/model_cases.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import json
-from dataclasses import dataclass
+from dataclasses import MISSING, dataclass, fields, is_dataclass
 from types import GenericAlias
-from typing import Any, Mapping
+from typing import Any, Callable, get_type_hints
 
 import pytest
 
@@ -22,6 +22,11 @@ MODEL_CASE_PARAMS = [
 
 
 @dataclass
+class SimpleModel:
+    user_id: int
+
+
+@dataclass
 class RootModelLookalike:
     __root__: list[str]
 
@@ -30,12 +35,15 @@ class RootModelLookalike:
 class ModelCase:
     name: str
     adapter: ModelAdapterType
-    model_base: Any
+    _convert_dataclass: Callable[[type[Any]], Any]
     simple_model: Any
     dummy_root_model: Any
     nested_root_model: Any
     users_model: Any
     root_model_lookalike: type[RootModelLookalike] = RootModelLookalike
+
+    def convert_dataclass(self, model_decl: type[Any]) -> Any:
+        return self._convert_dataclass(model_decl)
 
     def validate_obj(self, model: Any, value: Any) -> Any:
         return self.adapter.validate_obj(model, value)
@@ -46,22 +54,78 @@ class ModelCase:
     def dump_python(self, value: Any) -> Any:
         return json.loads(self.adapter.dump_json(value))
 
-    def make_model(self, name: str, fields: Mapping[str, Any]) -> Any:
-        return _make_model(name, self.model_base, fields)
-
     def list_of(self, model: Any) -> Any:
         return GenericAlias(list, (model,))
 
 
-def _make_model(name: str, base: Any, fields: Mapping[str, Any]) -> Any:
-    return type(
-        name,
-        (base,),
-        {
-            "__annotations__": dict(fields),
-            "__module__": __name__,
-        },
-    )
+def _dataclass_field_types(model_decl: type[Any]) -> list[tuple[Any, Any]]:
+    if not is_dataclass(model_decl):
+        raise TypeError(f"{model_decl!r} is not a dataclass")
+
+    type_hints = get_type_hints(model_decl, include_extras=True)
+    return [
+        (model_field, type_hints.get(model_field.name, model_field.type))
+        for model_field in fields(model_decl)
+    ]
+
+
+def _build_pydantic_dataclass_converter(pydantic) -> Callable[[type[Any]], Any]:
+    cache: dict[type[Any], Any] = {}
+
+    def convert(model_decl: type[Any]) -> Any:
+        if model_decl in cache:
+            return cache[model_decl]
+
+        field_definitions = {}
+        for model_field, type_hint in _dataclass_field_types(model_decl):
+            if model_field.default_factory is not MISSING:
+                default = pydantic.Field(default_factory=model_field.default_factory)
+            elif model_field.default is not MISSING:
+                default = model_field.default
+            else:
+                default = ...
+            field_definitions[model_field.name] = (type_hint, default)
+
+        model = pydantic.create_model(
+            model_decl.__name__,
+            __base__=pydantic.BaseModel,
+            __module__=model_decl.__module__,
+            **field_definitions,
+        )
+        cache[model_decl] = model
+        return model
+
+    return convert
+
+
+def _build_msgspec_dataclass_converter(msgspec) -> Callable[[type[Any]], Any]:
+    cache: dict[type[Any], Any] = {}
+
+    def convert(model_decl: type[Any]) -> Any:
+        if model_decl in cache:
+            return cache[model_decl]
+
+        field_definitions: list[Any] = []
+        for model_field, type_hint in _dataclass_field_types(model_decl):
+            if model_field.default_factory is not MISSING:
+                default = msgspec.field(default_factory=model_field.default_factory)
+                field_definitions.append((model_field.name, type_hint, default))
+            elif model_field.default is not MISSING:
+                field_definitions.append(
+                    (model_field.name, type_hint, model_field.default)
+                )
+            else:
+                field_definitions.append((model_field.name, type_hint))
+
+        model = msgspec.defstruct(
+            model_decl.__name__,
+            field_definitions,
+            module=model_decl.__module__,
+        )
+        cache[model_decl] = model
+        return model
+
+    return convert
 
 
 def build_model_case(name: str) -> ModelCase:
@@ -78,8 +142,8 @@ def _build_pydantic_case() -> ModelCase:
 
     pydantic = importlib.import_module("pydantic")
     adapter = get_pydantic_model_adapter()
-    model_base = pydantic.BaseModel
-    SimpleModel = _make_model("SimpleModel", model_base, {"user_id": int})
+    convert_dataclass = _build_pydantic_dataclass_converter(pydantic)
+    simple_model = convert_dataclass(SimpleModel)
 
     dummy_root_model = adapter.make_root_model(
         list[int],
@@ -92,7 +156,7 @@ def _build_pydantic_case() -> ModelCase:
         module=__name__,
     )
     users_model = adapter.make_root_model(
-        GenericAlias(list, (SimpleModel,)),
+        GenericAlias(list, (simple_model,)),
         name="Users",
         module=__name__,
     )
@@ -100,8 +164,8 @@ def _build_pydantic_case() -> ModelCase:
     return ModelCase(
         name="pydantic",
         adapter=adapter,
-        model_base=model_base,
-        simple_model=SimpleModel,
+        _convert_dataclass=convert_dataclass,
+        simple_model=simple_model,
         dummy_root_model=dummy_root_model,
         nested_root_model=nested_root_model,
         users_model=users_model,
@@ -114,8 +178,8 @@ def _build_msgspec_case() -> ModelCase:
 
     msgspec = importlib.import_module("msgspec")
     adapter = get_msgspec_model_adapter()
-    model_base = msgspec.Struct
-    SimpleModel = _make_model("SimpleModel", model_base, {"user_id": int})
+    convert_dataclass = _build_msgspec_dataclass_converter(msgspec)
+    simple_model = convert_dataclass(SimpleModel)
 
     dummy_root_model = adapter.make_root_model(
         list[int],
@@ -128,7 +192,7 @@ def _build_msgspec_case() -> ModelCase:
         module=__name__,
     )
     users_model = adapter.make_root_model(
-        GenericAlias(list, (SimpleModel,)),
+        GenericAlias(list, (simple_model,)),
         name="Users",
         module=__name__,
     )
@@ -136,8 +200,8 @@ def _build_msgspec_case() -> ModelCase:
     return ModelCase(
         name="msgspec",
         adapter=adapter,
-        model_base=model_base,
-        simple_model=SimpleModel,
+        _convert_dataclass=convert_dataclass,
+        simple_model=simple_model,
         dummy_root_model=dummy_root_model,
         nested_root_model=nested_root_model,
         users_model=users_model,

--- a/tests/model_cases.py
+++ b/tests/model_cases.py
@@ -4,8 +4,18 @@ import importlib
 import importlib.util
 import json
 from dataclasses import MISSING, dataclass, fields, is_dataclass
+from functools import lru_cache
 from types import GenericAlias
-from typing import Any, Callable, get_type_hints
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 import pytest
 
@@ -19,6 +29,11 @@ MODEL_CASE_PARAMS = [
     pytest.param("pydantic", id="pydantic"),
     pytest.param("msgspec", marks=pytest.mark.msgspec, id="msgspec"),
 ]
+
+DATACLASS_CONVERTER_CACHE_SIZE = 128
+MODEL_DEFINITION_CACHE_SIZE = 128
+DataclassConverter = Callable[[type[Any]], Any]
+ModelResolver = Callable[[Any | None, str | None], Any | None]
 
 
 @dataclass
@@ -35,15 +50,16 @@ class RootModelLookalike:
 class ModelCase:
     name: str
     adapter: ModelAdapterType
-    _convert_dataclass: Callable[[type[Any]], Any]
-    simple_model: Any
-    dummy_root_model: Any
-    nested_root_model: Any
-    users_model: Any
+    _get_model: ModelResolver
     root_model_lookalike: type[RootModelLookalike] = RootModelLookalike
 
-    def convert_dataclass(self, model_decl: type[Any]) -> Any:
-        return self._convert_dataclass(model_decl)
+    def get_model(
+        self,
+        model_def: Any | None,
+        *,
+        name: str | None = None,
+    ) -> Any | None:
+        return self._get_model(model_def, name)
 
     def validate_obj(self, model: Any, value: Any) -> Any:
         return self.adapter.validate_obj(model, value)
@@ -58,57 +74,100 @@ class ModelCase:
         return GenericAlias(list, (model,))
 
 
-def _dataclass_field_types(model_decl: type[Any]) -> list[tuple[Any, Any]]:
-    if not is_dataclass(model_decl):
-        raise TypeError(f"{model_decl!r} is not a dataclass")
+def _dataclass_field_types(model_def: type[Any]) -> list[tuple[Any, Any]]:
+    if not is_dataclass(model_def):
+        raise TypeError(f"{model_def!r} is not a dataclass")
 
-    type_hints = get_type_hints(model_decl, include_extras=True)
+    type_hints = get_type_hints(model_def, include_extras=True)
     return [
         (model_field, type_hints.get(model_field.name, model_field.type))
-        for model_field in fields(model_decl)
+        for model_field in fields(model_def)
     ]
 
 
-def _build_pydantic_dataclass_converter(pydantic) -> Callable[[type[Any]], Any]:
-    cache: dict[type[Any], Any] = {}
+def _build_model_resolver(
+    adapter: ModelAdapterType,
+    convert_dataclass: DataclassConverter,
+) -> ModelResolver:
+    def convert_type_def(type_def: Any) -> Any:
+        if is_dataclass(type_def):
+            return convert_dataclass(cast(type[Any], type_def))
 
-    def convert(model_decl: type[Any]) -> Any:
-        if model_decl in cache:
-            return cache[model_decl]
+        origin = get_origin(type_def)
+        if origin is None:
+            return type_def
 
+        args = tuple(convert_type_def(arg) for arg in get_args(type_def))
+        if origin is Union:
+            return Union[args]
+        if origin is Annotated:
+            return Annotated[args]
+        return GenericAlias(origin, args)
+
+    @lru_cache(maxsize=MODEL_DEFINITION_CACHE_SIZE)
+    def get_model(
+        model_def: Any | None,
+        name: str | None,
+    ) -> Any | None:
+        if model_def is None:
+            return None
+
+        converted_def = convert_type_def(model_def)
+        if is_dataclass(model_def):
+            return converted_def
+
+        origin = get_origin(model_def)
+        if origin is list and name is None:
+            item_model = get_args(converted_def)[0]
+            return adapter.make_list_model(item_model)
+
+        if name is None:
+            return adapter.make_root_model(converted_def, module=__name__)
+        return adapter.make_root_model(converted_def, name=name, module=__name__)
+
+    return cast(ModelResolver, get_model)
+
+
+def _build_pydantic_dataclass_converter() -> DataclassConverter:
+    pydantic = importlib.import_module("pydantic")
+    base_model = pydantic.BaseModel
+    create_model = pydantic.create_model
+    field = pydantic.Field
+
+    @lru_cache(maxsize=DATACLASS_CONVERTER_CACHE_SIZE)
+    def convert(model_def: type[Any]) -> Any:
         field_definitions = {}
-        for model_field, type_hint in _dataclass_field_types(model_decl):
+        for model_field, type_hint in _dataclass_field_types(model_def):
             if model_field.default_factory is not MISSING:
-                default = pydantic.Field(default_factory=model_field.default_factory)
+                default = field(default_factory=model_field.default_factory)
             elif model_field.default is not MISSING:
                 default = model_field.default
             else:
                 default = ...
             field_definitions[model_field.name] = (type_hint, default)
 
-        model = pydantic.create_model(
-            model_decl.__name__,
-            __base__=pydantic.BaseModel,
-            __module__=model_decl.__module__,
+        model = create_model(
+            model_def.__name__,
+            __base__=base_model,
+            __module__=model_def.__module__,
             **field_definitions,
         )
-        cache[model_decl] = model
         return model
 
-    return convert
+    return cast(DataclassConverter, convert)
 
 
-def _build_msgspec_dataclass_converter(msgspec) -> Callable[[type[Any]], Any]:
-    cache: dict[type[Any], Any] = {}
+def _build_msgspec_dataclass_converter() -> DataclassConverter:
+    msgspec = importlib.import_module("msgspec")
+    defstruct = msgspec.defstruct
+    field = msgspec.field
 
-    def convert(model_decl: type[Any]) -> Any:
-        if model_decl in cache:
-            return cache[model_decl]
-
+    @lru_cache(maxsize=DATACLASS_CONVERTER_CACHE_SIZE)
+    def convert(model_def: type[Any]) -> Any:
         field_definitions: list[Any] = []
-        for model_field, type_hint in _dataclass_field_types(model_decl):
+        for model_field, type_hint in _dataclass_field_types(model_def):
             if model_field.default_factory is not MISSING:
-                default = msgspec.field(default_factory=model_field.default_factory)
+                default = field(default_factory=model_field.default_factory)
                 field_definitions.append((model_field.name, type_hint, default))
             elif model_field.default is not MISSING:
                 field_definitions.append(
@@ -117,15 +176,14 @@ def _build_msgspec_dataclass_converter(msgspec) -> Callable[[type[Any]], Any]:
             else:
                 field_definitions.append((model_field.name, type_hint))
 
-        model = msgspec.defstruct(
-            model_decl.__name__,
+        model = defstruct(
+            model_def.__name__,
             field_definitions,
-            module=model_decl.__module__,
+            module=model_def.__module__,
         )
-        cache[model_decl] = model
         return model
 
-    return convert
+    return cast(DataclassConverter, convert)
 
 
 def build_model_case(name: str) -> ModelCase:
@@ -140,35 +198,13 @@ def _build_pydantic_case() -> ModelCase:
     if importlib.util.find_spec("pydantic") is None:
         pytest.skip("pydantic is not installed")
 
-    pydantic = importlib.import_module("pydantic")
     adapter = get_pydantic_model_adapter()
-    convert_dataclass = _build_pydantic_dataclass_converter(pydantic)
-    simple_model = convert_dataclass(SimpleModel)
-
-    dummy_root_model = adapter.make_root_model(
-        list[int],
-        name="DummyRootModel",
-        module=__name__,
-    )
-    nested_root_model = adapter.make_root_model(
-        dummy_root_model,
-        name="NestedRootModel",
-        module=__name__,
-    )
-    users_model = adapter.make_root_model(
-        GenericAlias(list, (simple_model,)),
-        name="Users",
-        module=__name__,
-    )
+    convert_dataclass = _build_pydantic_dataclass_converter()
 
     return ModelCase(
         name="pydantic",
         adapter=adapter,
-        _convert_dataclass=convert_dataclass,
-        simple_model=simple_model,
-        dummy_root_model=dummy_root_model,
-        nested_root_model=nested_root_model,
-        users_model=users_model,
+        _get_model=_build_model_resolver(adapter, convert_dataclass),
     )
 
 
@@ -176,33 +212,11 @@ def _build_msgspec_case() -> ModelCase:
     if importlib.util.find_spec("msgspec") is None:
         pytest.skip("msgspec is not installed")
 
-    msgspec = importlib.import_module("msgspec")
     adapter = get_msgspec_model_adapter()
-    convert_dataclass = _build_msgspec_dataclass_converter(msgspec)
-    simple_model = convert_dataclass(SimpleModel)
-
-    dummy_root_model = adapter.make_root_model(
-        list[int],
-        name="DummyRootModel",
-        module=__name__,
-    )
-    nested_root_model = adapter.make_root_model(
-        dummy_root_model,
-        name="NestedRootModel",
-        module=__name__,
-    )
-    users_model = adapter.make_root_model(
-        GenericAlias(list, (simple_model,)),
-        name="Users",
-        module=__name__,
-    )
+    convert_dataclass = _build_msgspec_dataclass_converter()
 
     return ModelCase(
         name="msgspec",
         adapter=adapter,
-        _convert_dataclass=convert_dataclass,
-        simple_model=simple_model,
-        dummy_root_model=dummy_root_model,
-        nested_root_model=nested_root_model,
-        users_model=users_model,
+        _get_model=_build_model_resolver(adapter, convert_dataclass),
     )

--- a/tests/model_cases.py
+++ b/tests/model_cases.py
@@ -121,8 +121,6 @@ def _build_model_resolver(
             item_model = get_args(converted_def)[0]
             return adapter.make_list_model(item_model)
 
-        if name is None:
-            return adapter.make_root_model(converted_def, module=__name__)
         return adapter.make_root_model(converted_def, name=name, module=__name__)
 
     return cast(ModelResolver, get_model)

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1,8 +1,8 @@
 import json
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime
-from typing import Any, Union
+from typing import Union
 
 import pytest
 
@@ -37,204 +37,135 @@ class ComplexResp:
     uuid: uuid.UUID
 
 
-def _union_of(*types_: Any) -> Any:
-    return Union[types_]
-
-
-ROOT_RESP_DEF = _union_of(JSON, list[int])
-STR_DICT_DEF = dict[str, str]
-RESP_LIST_DEF = list[Resp]
-
-
-@dataclass(frozen=True, slots=True)
-class ResponsePayloads:
-    model_case: Any
-
-    @property
-    def resp(self) -> Any:
-        return self.model_case.get_model(Resp)
-
-    @property
-    def json(self) -> Any:
-        return self.model_case.get_model(JSON)
-
-    @property
-    def root_resp(self) -> Any:
-        return self.model_case.get_model(ROOT_RESP_DEF)
-
-    @property
-    def str_dict(self) -> Any:
-        return self.model_case.get_model(STR_DICT_DEF)
-
-    @property
-    def complex_resp(self) -> Any:
-        return self.model_case.get_model(ComplexResp)
-
-    def response_payload(self, name: str) -> Any:
-        method_name = name.replace("-", "_")
-        try:
-            builder = getattr(self, method_name)
-        except AttributeError as exc:
-            raise ValueError(f"unknown response payload case: {name}") from exc
-        return builder()
-
-    def resp_instance(self):
-        return self.resp(name="user1", score=[1, 2])
-
-    def resp_dict(self):
-        return {"name": "user1", "score": [1, 2]}
-
-    def resp_raw_dict(self):
-        return RawResponsePayload({"name": "user1", "score": [1, 2]})
-
-    def empty_dict(self):
-        return {}
-
-    def resp_missing_score(self):
-        return {"name": "user1"}
-
-    def root_list(self):
-        return [1, 2, 3]
-
-    def root_raw_list(self):
-        return RawResponsePayload([1, 2, 3])
-
-    def str_dict_instance(self):
-        return self.model_case.validate_obj(
-            self.str_dict,
-            {"key1": "value1", "key2": "value2"},
-        )
-
-    def root_json_dict(self):
-        return {"name": "user2", "limit": 1}
-
-    def root_raw_json_dict(self):
-        return RawResponsePayload({"name": "user2", "limit": 1})
-
-    def json_instance(self):
-        return self.json(name="user3", limit=5)
-
-    def root_json_instance(self):
-        return self.model_case.validate_obj(
-            self.root_resp,
-            self.json(name="user4", limit=23),
-        )
-
-    def empty_list(self):
-        return []
-
-    def resp_list_dict(self):
-        return [{"name": "user5", "score": [5, 10]}]
-
-    def resp_list_instances(self):
-        return [
-            self.resp(name="user6", score=[10, 20]),
-            self.resp(name="user7", score=[30, 40]),
-        ]
-
-    def plain_dict(self):
-        return {"user_id": "user1", "locale": "en-gb"}
-
-    def dummy_response(self):
-        return DummyResponse(
-            payload="<html></html>".encode(),
-            content_type="text/html",
-        )
-
-    def complex_instance(self):
-        return self.complex_resp(
-            date=datetime(2025, 1, 1),
-            uuid=uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
-        )
-
-
-@pytest.fixture
-def response_payloads(model_case):
-    return ResponsePayloads(model_case=model_case)
-
-
-def _normalize_result(result: ResponseValidationResult) -> ResponseValidationResult:
-    payload = result.payload
-    if isinstance(payload, bytes):
-        payload = json.loads(payload)
-    return ResponseValidationResult(payload)
-
-
 @pytest.mark.parametrize(
-    "validation_model_def, response_payload_name, expected_payload",
+    "validation_model_def, response_payload, expected_payload",
     [
-        (Resp, "resp-instance", {"name": "user1", "score": [1, 2]}),
-        (Resp, "resp-dict", {"name": "user1", "score": [1, 2]}),
-        (Resp, "resp-raw-dict", {"name": "user1", "score": [1, 2]}),
-        (ROOT_RESP_DEF, "root-list", [1, 2, 3]),
-        (ROOT_RESP_DEF, "root-raw-list", [1, 2, 3]),
+        (Resp, {"name": "user1", "score": [1, 2]}, {"name": "user1", "score": [1, 2]}),
         (
-            STR_DICT_DEF,
-            "str-dict-instance",
+            Resp,
+            RawResponsePayload({"name": "user1", "score": [1, 2]}),
+            {"name": "user1", "score": [1, 2]},
+        ),
+        (
+            Resp,
+            Resp(name="user1", score=[1, 2]),
+            {"name": "user1", "score": [1, 2]},
+        ),
+        (Union[JSON, list[int]], [1, 2, 3], [1, 2, 3]),
+        (Union[JSON, list[int]], RawResponsePayload([1, 2, 3]), [1, 2, 3]),
+        (
+            dict[str, str],
+            {"key1": "value1", "key2": "value2"},
             {"key1": "value1", "key2": "value2"},
         ),
-        (ROOT_RESP_DEF, "root-json-dict", {"name": "user2", "limit": 1}),
-        (ROOT_RESP_DEF, "root-raw-json-dict", {"name": "user2", "limit": 1}),
-        (ROOT_RESP_DEF, "json-instance", {"name": "user3", "limit": 5}),
-        (ROOT_RESP_DEF, "root-json-instance", {"name": "user4", "limit": 23}),
-        (RESP_LIST_DEF, "empty-list", []),
-        (RESP_LIST_DEF, "resp-list-dict", [{"name": "user5", "score": [5, 10]}]),
         (
-            RESP_LIST_DEF,
-            "resp-list-instances",
+            Union[JSON, list[int]],
+            {"name": "user2", "limit": 1},
+            {"name": "user2", "limit": 1},
+        ),
+        (
+            Union[JSON, list[int]],
+            RawResponsePayload({"name": "user2", "limit": 1}),
+            {"name": "user2", "limit": 1},
+        ),
+        (list[Resp], [], []),
+        (
+            list[Resp],
+            [{"name": "user5", "score": [5, 10]}],
+            [
+                {"name": "user5", "score": [5, 10]},
+            ],
+        ),
+        (
+            list[Resp],
+            [
+                Resp(name="user6", score=[10, 20]),
+                Resp(name="user7", score=[30, 40]),
+            ],
             [
                 {"name": "user6", "score": [10, 20]},
                 {"name": "user7", "score": [30, 40]},
             ],
         ),
-        (None, "plain-dict", {"user_id": "user1", "locale": "en-gb"}),
         (
             None,
-            "dummy-response",
+            {"user_id": "user1", "locale": "en-gb"},
+            {"user_id": "user1", "locale": "en-gb"},
+        ),
+        (
+            None,
+            DummyResponse(payload="<html></html>".encode(), content_type="text/html"),
             DummyResponse(payload="<html></html>".encode(), content_type="text/html"),
         ),
         (
             ComplexResp,
-            "complex-instance",
             {
-                "date": "2025-01-01T00:00:00",
-                "uuid": "48b417cd-a884-4e54-9f5b-85c584e5ce77",
+                "date": datetime(2025, 1, 1),
+                "uuid": uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
+            },
+            {
+                "date": datetime(2025, 1, 1),
+                "uuid": uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
             },
         ),
     ],
 )
 def test_validate_response(
     model_case,
-    response_payloads,
     validation_model_def,
-    response_payload_name,
+    response_payload,
     expected_payload,
 ):
+    validation_model = model_case.get_model(validation_model_def)
+    if (
+        validation_model is not None
+        and is_dataclass(response_payload)
+        and not isinstance(response_payload, RawResponsePayload)
+    ):
+        response_payload = model_case.validate_obj(
+            model_case.get_model(type(response_payload)),
+            asdict(response_payload),
+        )
+    elif (
+        validation_model is not None
+        and isinstance(response_payload, list)
+        and any(is_dataclass(item) for item in response_payload)
+    ):
+        response_payload = [
+            model_case.validate_obj(model_case.get_model(type(item)), asdict(item))
+            if is_dataclass(item)
+            else item
+            for item in response_payload
+        ]
+
     result = validate_response(
         model_adapter=model_case.adapter,
-        validation_model=model_case.get_model(validation_model_def),
-        response_payload=response_payloads.response_payload(response_payload_name),
+        validation_model=validation_model,
+        response_payload=response_payload,
     )
+    payload = result.payload
+    if isinstance(payload, bytes):
+        payload = json.loads(payload)
 
-    assert _normalize_result(result) == ResponseValidationResult(expected_payload)
+    assert ResponseValidationResult(payload) == ResponseValidationResult(
+        expected_payload
+    )
 
 
 @pytest.mark.parametrize(
-    "validation_model_def, response_payload_name",
+    "validation_model_def, response_payload",
     [
-        (Resp, "empty-dict"),
-        (Resp, "resp-missing-score"),
-        (ROOT_RESP_DEF, "empty-dict"),
+        (Resp, {}),
+        (Resp, {"name": "user1"}),
+        (Union[JSON, list[int]], {}),
     ],
 )
 def test_validate_response_rejects_invalid_payload(
     model_case,
-    response_payloads,
     validation_model_def,
-    response_payload_name,
+    response_payload,
 ):
     validation_model = model_case.get_model(validation_model_def)
-    response_payload = response_payloads.response_payload(response_payload_name)
 
     with pytest.raises(model_case.adapter.validation_error):
         validate_response(

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -2,11 +2,10 @@ import json
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import pytest
 
-from spectree.model_adapter import ModelClass
 from spectree.plugins.base import (
     RawResponsePayload,
     ResponseValidationResult,
@@ -38,23 +37,49 @@ class ComplexResp:
     uuid: uuid.UUID
 
 
-@dataclass(frozen=True, slots=True)
-class BasePluginModels:
-    resp: Any
-    json: Any
-    root_resp: Any
-    str_dict: Any
-    complex_resp: Any
-    resp_list: Any
+def _union_of(*types_: Any) -> Any:
+    return Union[types_]
+
+
+ROOT_RESP_DEF = _union_of(JSON, list[int])
+STR_DICT_DEF = dict[str, str]
+RESP_LIST_DEF = list[Resp]
 
 
 @dataclass(frozen=True, slots=True)
-class ResponsePayloadFactory:
+class ResponsePayloads:
     model_case: Any
-    models: BasePluginModels
+
+    @property
+    def resp(self) -> Any:
+        return self.model_case.get_model(Resp)
+
+    @property
+    def json(self) -> Any:
+        return self.model_case.get_model(JSON)
+
+    @property
+    def root_resp(self) -> Any:
+        return self.model_case.get_model(ROOT_RESP_DEF)
+
+    @property
+    def str_dict(self) -> Any:
+        return self.model_case.get_model(STR_DICT_DEF)
+
+    @property
+    def complex_resp(self) -> Any:
+        return self.model_case.get_model(ComplexResp)
+
+    def response_payload(self, name: str) -> Any:
+        method_name = name.replace("-", "_")
+        try:
+            builder = getattr(self, method_name)
+        except AttributeError as exc:
+            raise ValueError(f"unknown response payload case: {name}") from exc
+        return builder()
 
     def resp_instance(self):
-        return self.models.resp(name="user1", score=[1, 2])
+        return self.resp(name="user1", score=[1, 2])
 
     def resp_dict(self):
         return {"name": "user1", "score": [1, 2]}
@@ -76,7 +101,7 @@ class ResponsePayloadFactory:
 
     def str_dict_instance(self):
         return self.model_case.validate_obj(
-            self.models.str_dict,
+            self.str_dict,
             {"key1": "value1", "key2": "value2"},
         )
 
@@ -87,12 +112,12 @@ class ResponsePayloadFactory:
         return RawResponsePayload({"name": "user2", "limit": 1})
 
     def json_instance(self):
-        return self.models.json(name="user3", limit=5)
+        return self.json(name="user3", limit=5)
 
     def root_json_instance(self):
         return self.model_case.validate_obj(
-            self.models.root_resp,
-            self.models.json(name="user4", limit=23),
+            self.root_resp,
+            self.json(name="user4", limit=23),
         )
 
     def empty_list(self):
@@ -103,8 +128,8 @@ class ResponsePayloadFactory:
 
     def resp_list_instances(self):
         return [
-            self.models.resp(name="user6", score=[10, 20]),
-            self.models.resp(name="user7", score=[30, 40]),
+            self.resp(name="user6", score=[10, 20]),
+            self.resp(name="user7", score=[30, 40]),
         ]
 
     def plain_dict(self):
@@ -117,56 +142,15 @@ class ResponsePayloadFactory:
         )
 
     def complex_instance(self):
-        return self.models.complex_resp(
+        return self.complex_resp(
             date=datetime(2025, 1, 1),
             uuid=uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
         )
 
 
-def _union_of(*types_: Any) -> Any:
-    return Union[types_]
-
-
 @pytest.fixture
-def base_plugin_models(model_case):
-    resp_model = model_case.convert_dataclass(Resp)
-    json_model = model_case.convert_dataclass(JSON)
-    complex_resp_model = model_case.convert_dataclass(ComplexResp)
-    root_resp_model = model_case.adapter.make_root_model(
-        _union_of(json_model, list[int]),
-        name="RootResp",
-        module=__name__,
-    )
-    str_dict_model = model_case.adapter.make_root_model(
-        dict[str, str],
-        name="StrDict",
-        module=__name__,
-    )
-
-    return BasePluginModels(
-        resp=resp_model,
-        json=json_model,
-        root_resp=root_resp_model,
-        str_dict=str_dict_model,
-        complex_resp=complex_resp_model,
-        resp_list=model_case.adapter.make_list_model(resp_model),
-    )
-
-
-def _get_model(models: BasePluginModels, name: Optional[str]) -> Optional[ModelClass]:
-    if name is None:
-        return None
-    return getattr(models, name)
-
-
-def _get_response_payload(model_case, models: BasePluginModels, name: str):
-    factory = ResponsePayloadFactory(model_case, models)
-    method_name = name.replace("-", "_")
-    try:
-        builder = getattr(factory, method_name)
-    except AttributeError as exc:
-        raise ValueError(f"unknown response payload case: {name}") from exc
-    return builder()
+def response_payloads(model_case):
+    return ResponsePayloads(model_case=model_case)
 
 
 def _normalize_result(result: ResponseValidationResult) -> ResponseValidationResult:
@@ -177,26 +161,26 @@ def _normalize_result(result: ResponseValidationResult) -> ResponseValidationRes
 
 
 @pytest.mark.parametrize(
-    "validation_model_name, response_payload_name, expected_payload",
+    "validation_model_def, response_payload_name, expected_payload",
     [
-        ("resp", "resp-instance", {"name": "user1", "score": [1, 2]}),
-        ("resp", "resp-dict", {"name": "user1", "score": [1, 2]}),
-        ("resp", "resp-raw-dict", {"name": "user1", "score": [1, 2]}),
-        ("root_resp", "root-list", [1, 2, 3]),
-        ("root_resp", "root-raw-list", [1, 2, 3]),
+        (Resp, "resp-instance", {"name": "user1", "score": [1, 2]}),
+        (Resp, "resp-dict", {"name": "user1", "score": [1, 2]}),
+        (Resp, "resp-raw-dict", {"name": "user1", "score": [1, 2]}),
+        (ROOT_RESP_DEF, "root-list", [1, 2, 3]),
+        (ROOT_RESP_DEF, "root-raw-list", [1, 2, 3]),
         (
-            "str_dict",
+            STR_DICT_DEF,
             "str-dict-instance",
             {"key1": "value1", "key2": "value2"},
         ),
-        ("root_resp", "root-json-dict", {"name": "user2", "limit": 1}),
-        ("root_resp", "root-raw-json-dict", {"name": "user2", "limit": 1}),
-        ("root_resp", "json-instance", {"name": "user3", "limit": 5}),
-        ("root_resp", "root-json-instance", {"name": "user4", "limit": 23}),
-        ("resp_list", "empty-list", []),
-        ("resp_list", "resp-list-dict", [{"name": "user5", "score": [5, 10]}]),
+        (ROOT_RESP_DEF, "root-json-dict", {"name": "user2", "limit": 1}),
+        (ROOT_RESP_DEF, "root-raw-json-dict", {"name": "user2", "limit": 1}),
+        (ROOT_RESP_DEF, "json-instance", {"name": "user3", "limit": 5}),
+        (ROOT_RESP_DEF, "root-json-instance", {"name": "user4", "limit": 23}),
+        (RESP_LIST_DEF, "empty-list", []),
+        (RESP_LIST_DEF, "resp-list-dict", [{"name": "user5", "score": [5, 10]}]),
         (
-            "resp_list",
+            RESP_LIST_DEF,
             "resp-list-instances",
             [
                 {"name": "user6", "score": [10, 20]},
@@ -210,7 +194,7 @@ def _normalize_result(result: ResponseValidationResult) -> ResponseValidationRes
             DummyResponse(payload="<html></html>".encode(), content_type="text/html"),
         ),
         (
-            "complex_resp",
+            ComplexResp,
             "complex-instance",
             {
                 "date": "2025-01-01T00:00:00",
@@ -221,44 +205,36 @@ def _normalize_result(result: ResponseValidationResult) -> ResponseValidationRes
 )
 def test_validate_response(
     model_case,
-    base_plugin_models,
-    validation_model_name,
+    response_payloads,
+    validation_model_def,
     response_payload_name,
     expected_payload,
 ):
     result = validate_response(
         model_adapter=model_case.adapter,
-        validation_model=_get_model(base_plugin_models, validation_model_name),
-        response_payload=_get_response_payload(
-            model_case,
-            base_plugin_models,
-            response_payload_name,
-        ),
+        validation_model=model_case.get_model(validation_model_def),
+        response_payload=response_payloads.response_payload(response_payload_name),
     )
 
     assert _normalize_result(result) == ResponseValidationResult(expected_payload)
 
 
 @pytest.mark.parametrize(
-    "validation_model_name, response_payload_name",
+    "validation_model_def, response_payload_name",
     [
-        ("resp", "empty-dict"),
-        ("resp", "resp-missing-score"),
-        ("root_resp", "empty-dict"),
+        (Resp, "empty-dict"),
+        (Resp, "resp-missing-score"),
+        (ROOT_RESP_DEF, "empty-dict"),
     ],
 )
 def test_validate_response_rejects_invalid_payload(
     model_case,
-    base_plugin_models,
-    validation_model_name,
+    response_payloads,
+    validation_model_def,
     response_payload_name,
 ):
-    validation_model = _get_model(base_plugin_models, validation_model_name)
-    response_payload = _get_response_payload(
-        model_case,
-        base_plugin_models,
-        response_payload_name,
-    )
+    validation_model = model_case.get_model(validation_model_def)
+    response_payload = response_payloads.response_payload(response_payload_name)
 
     with pytest.raises(model_case.adapter.validation_error):
         validate_response(

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1,22 +1,17 @@
 import json
 import uuid
-from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional, Union
 
 import pytest
-from pydantic import ValidationError
 
-from spectree.model_adapter import ModelClass, get_pydantic_model_adapter
+from spectree.model_adapter import ModelClass
 from spectree.plugins.base import (
     RawResponsePayload,
     ResponseValidationResult,
     validate_response,
 )
-from tests.common import JSON, ComplexResp, Resp, RootResp, StrDict
-
-RespList = get_pydantic_model_adapter().make_list_model(Resp)
 
 
 @dataclass(frozen=True)
@@ -25,147 +20,249 @@ class DummyResponse:
     content_type: str
 
 
+@dataclass
+class Resp:
+    name: str
+    score: list[int]
+
+
+@dataclass
+class JSON:
+    name: str
+    limit: int
+
+
+@dataclass
+class ComplexResp:
+    date: datetime
+    uuid: uuid.UUID
+
+
+@dataclass(frozen=True, slots=True)
+class BasePluginModels:
+    resp: Any
+    json: Any
+    root_resp: Any
+    str_dict: Any
+    complex_resp: Any
+    resp_list: Any
+
+
+@dataclass(frozen=True, slots=True)
+class ResponsePayloadFactory:
+    model_case: Any
+    models: BasePluginModels
+
+    def resp_instance(self):
+        return self.models.resp(name="user1", score=[1, 2])
+
+    def resp_dict(self):
+        return {"name": "user1", "score": [1, 2]}
+
+    def resp_raw_dict(self):
+        return RawResponsePayload({"name": "user1", "score": [1, 2]})
+
+    def empty_dict(self):
+        return {}
+
+    def resp_missing_score(self):
+        return {"name": "user1"}
+
+    def root_list(self):
+        return [1, 2, 3]
+
+    def root_raw_list(self):
+        return RawResponsePayload([1, 2, 3])
+
+    def str_dict_instance(self):
+        return self.model_case.validate_obj(
+            self.models.str_dict,
+            {"key1": "value1", "key2": "value2"},
+        )
+
+    def root_json_dict(self):
+        return {"name": "user2", "limit": 1}
+
+    def root_raw_json_dict(self):
+        return RawResponsePayload({"name": "user2", "limit": 1})
+
+    def json_instance(self):
+        return self.models.json(name="user3", limit=5)
+
+    def root_json_instance(self):
+        return self.model_case.validate_obj(
+            self.models.root_resp,
+            self.models.json(name="user4", limit=23),
+        )
+
+    def empty_list(self):
+        return []
+
+    def resp_list_dict(self):
+        return [{"name": "user5", "score": [5, 10]}]
+
+    def resp_list_instances(self):
+        return [
+            self.models.resp(name="user6", score=[10, 20]),
+            self.models.resp(name="user7", score=[30, 40]),
+        ]
+
+    def plain_dict(self):
+        return {"user_id": "user1", "locale": "en-gb"}
+
+    def dummy_response(self):
+        return DummyResponse(
+            payload="<html></html>".encode(),
+            content_type="text/html",
+        )
+
+    def complex_instance(self):
+        return self.models.complex_resp(
+            date=datetime(2025, 1, 1),
+            uuid=uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
+        )
+
+
+def _union_of(*types_: Any) -> Any:
+    return Union[types_]
+
+
+@pytest.fixture
+def base_plugin_models(model_case):
+    resp_model = model_case.convert_dataclass(Resp)
+    json_model = model_case.convert_dataclass(JSON)
+    complex_resp_model = model_case.convert_dataclass(ComplexResp)
+    root_resp_model = model_case.adapter.make_root_model(
+        _union_of(json_model, list[int]),
+        name="RootResp",
+        module=__name__,
+    )
+    str_dict_model = model_case.adapter.make_root_model(
+        dict[str, str],
+        name="StrDict",
+        module=__name__,
+    )
+
+    return BasePluginModels(
+        resp=resp_model,
+        json=json_model,
+        root_resp=root_resp_model,
+        str_dict=str_dict_model,
+        complex_resp=complex_resp_model,
+        resp_list=model_case.adapter.make_list_model(resp_model),
+    )
+
+
+def _get_model(models: BasePluginModels, name: Optional[str]) -> Optional[ModelClass]:
+    if name is None:
+        return None
+    return getattr(models, name)
+
+
+def _get_response_payload(model_case, models: BasePluginModels, name: str):
+    factory = ResponsePayloadFactory(model_case, models)
+    method_name = name.replace("-", "_")
+    try:
+        builder = getattr(factory, method_name)
+    except AttributeError as exc:
+        raise ValueError(f"unknown response payload case: {name}") from exc
+    return builder()
+
+
+def _normalize_result(result: ResponseValidationResult) -> ResponseValidationResult:
+    payload = result.payload
+    if isinstance(payload, bytes):
+        payload = json.loads(payload)
+    return ResponseValidationResult(payload)
+
+
 @pytest.mark.parametrize(
+    "validation_model_name, response_payload_name, expected_payload",
     [
-        "validation_model",
-        "response_payload",
-        "expected_result",
-    ],
-    [
+        ("resp", "resp-instance", {"name": "user1", "score": [1, 2]}),
+        ("resp", "resp-dict", {"name": "user1", "score": [1, 2]}),
+        ("resp", "resp-raw-dict", {"name": "user1", "score": [1, 2]}),
+        ("root_resp", "root-list", [1, 2, 3]),
+        ("root_resp", "root-raw-list", [1, 2, 3]),
         (
-            Resp,
-            Resp(name="user1", score=[1, 2]),
-            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
+            "str_dict",
+            "str-dict-instance",
+            {"key1": "value1", "key2": "value2"},
         ),
+        ("root_resp", "root-json-dict", {"name": "user2", "limit": 1}),
+        ("root_resp", "root-raw-json-dict", {"name": "user2", "limit": 1}),
+        ("root_resp", "json-instance", {"name": "user3", "limit": 5}),
+        ("root_resp", "root-json-instance", {"name": "user4", "limit": 23}),
+        ("resp_list", "empty-list", []),
+        ("resp_list", "resp-list-dict", [{"name": "user5", "score": [5, 10]}]),
         (
-            Resp,
-            {"name": "user1", "score": [1, 2]},
-            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
+            "resp_list",
+            "resp-list-instances",
+            [
+                {"name": "user6", "score": [10, 20]},
+                {"name": "user7", "score": [30, 40]},
+            ],
         ),
-        (
-            Resp,
-            RawResponsePayload({"name": "user1", "score": [1, 2]}),
-            ResponseValidationResult({"name": "user1", "score": [1, 2]}),
-        ),
-        (
-            Resp,
-            {},
-            ValidationError,
-        ),
-        (
-            Resp,
-            {"name": "user1"},
-            ValidationError,
-        ),
-        (
-            RootResp,
-            [1, 2, 3],
-            ResponseValidationResult([1, 2, 3]),
-        ),
-        (
-            RootResp,
-            RawResponsePayload([1, 2, 3]),
-            ResponseValidationResult([1, 2, 3]),
-        ),
-        (
-            StrDict,
-            StrDict.model_validate({"key1": "value1", "key2": "value2"}),
-            ResponseValidationResult({"key1": "value1", "key2": "value2"}),
-        ),
-        (
-            RootResp,
-            {"name": "user2", "limit": 1},
-            ResponseValidationResult({"name": "user2", "limit": 1}),
-        ),
-        (
-            RootResp,
-            RawResponsePayload({"name": "user2", "limit": 1}),
-            ResponseValidationResult({"name": "user2", "limit": 1}),
-        ),
-        (
-            RootResp,
-            JSON(name="user3", limit=5),
-            ResponseValidationResult({"name": "user3", "limit": 5}),
-        ),
-        (
-            RootResp,
-            RootResp.model_validate(JSON(name="user4", limit=23)),
-            ResponseValidationResult({"name": "user4", "limit": 23}),
-        ),
-        (
-            RootResp,
-            {},
-            ValidationError,
-        ),
-        (
-            RespList,
-            [],
-            ResponseValidationResult([]),
-        ),
-        (
-            RespList,
-            [{"name": "user5", "score": [5, 10]}],
-            ResponseValidationResult([{"name": "user5", "score": [5, 10]}]),
-        ),
-        (
-            RespList,
-            [Resp(name="user6", score=[10, 20]), Resp(name="user7", score=[30, 40])],
-            ResponseValidationResult(
-                [
-                    {"name": "user6", "score": [10, 20]},
-                    {"name": "user7", "score": [30, 40]},
-                ]
-            ),
-        ),
+        (None, "plain-dict", {"user_id": "user1", "locale": "en-gb"}),
         (
             None,
-            {"user_id": "user1", "locale": "en-gb"},
-            ResponseValidationResult({"user_id": "user1", "locale": "en-gb"}),
-        ),
-        (
-            None,
+            "dummy-response",
             DummyResponse(payload="<html></html>".encode(), content_type="text/html"),
-            ResponseValidationResult(
-                DummyResponse(
-                    payload="<html></html>".encode(), content_type="text/html"
-                )
-            ),
         ),
         (
-            ComplexResp,
-            ComplexResp(
-                date=datetime(2025, 1, 1),
-                uuid=uuid.UUID("48b417cd-a884-4e54-9f5b-85c584e5ce77"),
-            ),
-            ResponseValidationResult(
-                {
-                    "date": "2025-01-01T00:00:00",
-                    "uuid": "48b417cd-a884-4e54-9f5b-85c584e5ce77",
-                }
-            ),
+            "complex_resp",
+            "complex-instance",
+            {
+                "date": "2025-01-01T00:00:00",
+                "uuid": "48b417cd-a884-4e54-9f5b-85c584e5ce77",
+            },
         ),
     ],
 )
 def test_validate_response(
-    validation_model: Optional[ModelClass],
-    response_payload: Any,
-    expected_result: Union[ResponseValidationResult, ValidationError],
+    model_case,
+    base_plugin_models,
+    validation_model_name,
+    response_payload_name,
+    expected_payload,
 ):
-    runtime_expectation = (
-        pytest.raises(ValidationError)
-        if expected_result == ValidationError
-        else does_not_raise()
+    result = validate_response(
+        model_adapter=model_case.adapter,
+        validation_model=_get_model(base_plugin_models, validation_model_name),
+        response_payload=_get_response_payload(
+            model_case,
+            base_plugin_models,
+            response_payload_name,
+        ),
     )
-    with runtime_expectation:
-        result = validate_response(
-            model_adapter=get_pydantic_model_adapter(),
+
+    assert _normalize_result(result) == ResponseValidationResult(expected_payload)
+
+
+@pytest.mark.parametrize(
+    "validation_model_name, response_payload_name",
+    [
+        ("resp", "empty-dict"),
+        ("resp", "resp-missing-score"),
+        ("root_resp", "empty-dict"),
+    ],
+)
+def test_validate_response_rejects_invalid_payload(
+    model_case,
+    base_plugin_models,
+    validation_model_name,
+    response_payload_name,
+):
+    validation_model = _get_model(base_plugin_models, validation_model_name)
+    response_payload = _get_response_payload(
+        model_case,
+        base_plugin_models,
+        response_payload_name,
+    )
+
+    with pytest.raises(model_case.adapter.validation_error):
+        validate_response(
+            model_adapter=model_case.adapter,
             validation_model=validation_model,
             response_payload=response_payload,
         )
-        assert isinstance(result, ResponseValidationResult)
-        payload = (
-            ResponseValidationResult(json.loads(result.payload))
-            if isinstance(result.payload, bytes)
-            else result
-        )
-        assert payload == expected_result

--- a/tests/test_model_adapter_contract.py
+++ b/tests/test_model_adapter_contract.py
@@ -1,8 +1,10 @@
 import pytest
 
+from tests.model_cases import SimpleModel
+
 
 def _partial_model_instance_value(model_case, kind):
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
     values = {
         "model": simple_model(user_id=1),
         "list-with-model": [0, simple_model(user_id=1)],
@@ -19,7 +21,7 @@ def _partial_model_instance_value(model_case, kind):
 
 def test_validate_obj_and_is_model_instance(model_case):
     adapter = model_case.adapter
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
 
     instance = model_case.validate_obj(simple_model, {"user_id": "1"})
 
@@ -31,21 +33,26 @@ def test_validate_obj_and_is_model_instance(model_case):
 
 def test_root_model_instances(model_case):
     adapter = model_case.adapter
+    dummy_root_model = model_case.get_model(list[int], name="DummyRootModel")
+    nested_root_model = model_case.get_model(
+        dummy_root_model,
+        name="NestedRootModel",
+    )
 
     root_instance = model_case.validate_obj(
-        model_case.dummy_root_model,
+        dummy_root_model,
         [1, 2, 3],
     )
     nested_root_instance = model_case.validate_obj(
-        model_case.nested_root_model,
+        nested_root_model,
         root_instance,
     )
 
-    assert adapter.is_model_instance(root_instance, model_case.dummy_root_model) is True
+    assert adapter.is_model_instance(root_instance, dummy_root_model) is True
     assert (
         adapter.is_model_instance(
             nested_root_instance,
-            model_case.nested_root_model,
+            nested_root_model,
         )
         is True
     )
@@ -84,15 +91,18 @@ def test_is_partial_model_instance(model_case, kind, expected):
 
 
 def test_dump_json(model_case):
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
 
     assert model_case.dump_python(simple_model(user_id=1)) == {"user_id": 1}
     assert model_case.dump_python(
-        model_case.validate_obj(model_case.dummy_root_model, [1, 2, 3])
+        model_case.validate_obj(
+            model_case.get_model(list[int], name="DummyRootModel"),
+            [1, 2, 3],
+        )
     ) == [1, 2, 3]
     assert model_case.dump_python(
         model_case.validate_obj(
-            model_case.users_model,
+            model_case.get_model(list[SimpleModel], name="Users"),
             [
                 {"user_id": 1},
                 {"user_id": 2},
@@ -102,7 +112,7 @@ def test_dump_json(model_case):
 
 
 def test_validate_json_list_model(model_case):
-    list_model = model_case.adapter.make_list_model(model_case.simple_model)
+    list_model = model_case.adapter.make_list_model(model_case.get_model(SimpleModel))
     instance = model_case.validate_json(list_model, b'[{"user_id": 1}, {"user_id": 2}]')
 
     assert model_case.dump_python(instance) == [
@@ -113,7 +123,7 @@ def test_validate_json_list_model(model_case):
 
 def test_json_schema(model_case):
     schema = model_case.adapter.json_schema(
-        model_case.simple_model,
+        model_case.get_model(SimpleModel),
         ref_template="#/components/schemas/{model}",
     )
 
@@ -123,7 +133,7 @@ def test_json_schema(model_case):
 
 def test_validation_errors(model_case):
     with pytest.raises(model_case.adapter.validation_error) as exc_info:
-        model_case.validate_obj(model_case.simple_model, {"user_id": "bad"})
+        model_case.validate_obj(model_case.get_model(SimpleModel), {"user_id": "bad"})
 
     errors = model_case.adapter.validation_errors(exc_info.value)
 

--- a/tests/test_plugin_falcon_model_adapters.py
+++ b/tests/test_plugin_falcon_model_adapters.py
@@ -19,11 +19,27 @@ class FalconAdapterApp:
     raw_list_model: Any
 
 
+@dataclass
+class Query:
+    limit: int
+
+
+@dataclass
+class Payload:
+    name: str
+
+
+@dataclass
+class Item:
+    name: str
+    limit: int
+
+
 @pytest.fixture
 def falcon_adapter_app(model_case):
-    query_model = model_case.make_model("Query", {"limit": int})
-    payload_model = model_case.make_model("Payload", {"name": str})
-    item_model = model_case.make_model("Item", {"name": str, "limit": int})
+    query_model = model_case.convert_dataclass(Query)
+    payload_model = model_case.convert_dataclass(Payload)
+    item_model = model_case.convert_dataclass(Item)
     raw_list_model = model_case.list_of(item_model)
 
     spec = SpecTree(

--- a/tests/test_plugin_falcon_model_adapters.py
+++ b/tests/test_plugin_falcon_model_adapters.py
@@ -37,9 +37,9 @@ class Item:
 
 @pytest.fixture
 def falcon_adapter_app(model_case):
-    query_model = model_case.convert_dataclass(Query)
-    payload_model = model_case.convert_dataclass(Payload)
-    item_model = model_case.convert_dataclass(Item)
+    query_model = model_case.get_model(Query)
+    payload_model = model_case.get_model(Payload)
+    item_model = model_case.get_model(Item)
     raw_list_model = model_case.list_of(item_model)
 
     spec = SpecTree(
@@ -49,7 +49,7 @@ def falcon_adapter_app(model_case):
     )
 
     class Items:
-        def on_post(self, req, resp, query, json):
+        def on_post(self, req, resp, query: query_model, json: payload_model):
             resp.media = [
                 {
                     "name": json.name,
@@ -57,10 +57,6 @@ def falcon_adapter_app(model_case):
                 }
             ]
 
-    Items.on_post.__annotations__ = {
-        "query": query_model,
-        "json": payload_model,
-    }
     Items.on_post = spec.validate(resp=Response(HTTP_200=raw_list_model))(Items.on_post)
 
     app = falcon.App()

--- a/tests/test_plugin_flask_model_adapters.py
+++ b/tests/test_plugin_flask_model_adapters.py
@@ -36,19 +36,11 @@ class Item:
     limit: int
 
 
-def _annotate_handler(handler, query_model, payload_model):
-    handler.__annotations__ = {
-        "query": query_model,
-        "json": payload_model,
-    }
-    return handler
-
-
 @pytest.fixture
 def flask_adapter_app(model_case):
-    query_model = model_case.convert_dataclass(Query)
-    payload_model = model_case.convert_dataclass(Payload)
-    item_model = model_case.convert_dataclass(Item)
+    query_model = model_case.get_model(Query)
+    payload_model = model_case.get_model(Payload)
+    item_model = model_case.get_model(Item)
     raw_list_model = model_case.list_of(item_model)
 
     spec = SpecTree(
@@ -59,23 +51,17 @@ def flask_adapter_app(model_case):
     app = Flask(__name__)
     app.config["TESTING"] = True
 
-    def create_item(query, json):
+    def create_item(query: query_model, json: payload_model):
         return [{"name": json.name, "limit": query.limit}]
 
-    create_item = _annotate_handler(create_item, query_model, payload_model)
     create_item = spec.validate(resp=Response(HTTP_200=raw_list_model))(create_item)
     app.add_url_rule("/items", view_func=create_item, methods=["POST"])
 
     blueprint = Blueprint("adapter_blueprint", __name__)
 
-    def create_blueprint_item(query, json):
+    def create_blueprint_item(query: query_model, json: payload_model):
         return [{"name": json.name, "limit": query.limit}]
 
-    create_blueprint_item = _annotate_handler(
-        create_blueprint_item,
-        query_model,
-        payload_model,
-    )
     create_blueprint_item = spec.validate(resp=Response(HTTP_200=raw_list_model))(
         create_blueprint_item
     )
@@ -87,10 +73,9 @@ def flask_adapter_app(model_case):
     app.register_blueprint(blueprint, url_prefix="/bp")
 
     class ItemsView(MethodView):
-        def post(self, query, json):
+        def post(self, query: query_model, json: payload_model):
             return [{"name": json.name, "limit": query.limit}]
 
-    ItemsView.post = _annotate_handler(ItemsView.post, query_model, payload_model)
     ItemsView.post = spec.validate(resp=Response(HTTP_200=raw_list_model))(
         ItemsView.post
     )

--- a/tests/test_plugin_flask_model_adapters.py
+++ b/tests/test_plugin_flask_model_adapters.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from flask import Blueprint, Flask
+from flask.testing import FlaskClient
+from flask.views import MethodView
+
+from spectree import Response, SpecTree
+from spectree.utils import get_model_key
+
+
+@dataclass(frozen=True)
+class FlaskAdapterApp:
+    client: FlaskClient
+    spec: SpecTree
+    route_handlers: tuple[Any, ...]
+    item_model: Any
+    raw_list_model: Any
+
+
+@dataclass
+class Query:
+    limit: int
+
+
+@dataclass
+class Payload:
+    name: str
+
+
+@dataclass
+class Item:
+    name: str
+    limit: int
+
+
+def _annotate_handler(handler, query_model, payload_model):
+    handler.__annotations__ = {
+        "query": query_model,
+        "json": payload_model,
+    }
+    return handler
+
+
+@pytest.fixture
+def flask_adapter_app(model_case):
+    query_model = model_case.convert_dataclass(Query)
+    payload_model = model_case.convert_dataclass(Payload)
+    item_model = model_case.convert_dataclass(Item)
+    raw_list_model = model_case.list_of(item_model)
+
+    spec = SpecTree(
+        "flask",
+        annotations=True,
+        model_adapter=model_case.adapter,
+    )
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    def create_item(query, json):
+        return [{"name": json.name, "limit": query.limit}]
+
+    create_item = _annotate_handler(create_item, query_model, payload_model)
+    create_item = spec.validate(resp=Response(HTTP_200=raw_list_model))(create_item)
+    app.add_url_rule("/items", view_func=create_item, methods=["POST"])
+
+    blueprint = Blueprint("adapter_blueprint", __name__)
+
+    def create_blueprint_item(query, json):
+        return [{"name": json.name, "limit": query.limit}]
+
+    create_blueprint_item = _annotate_handler(
+        create_blueprint_item,
+        query_model,
+        payload_model,
+    )
+    create_blueprint_item = spec.validate(resp=Response(HTTP_200=raw_list_model))(
+        create_blueprint_item
+    )
+    blueprint.add_url_rule(
+        "/items",
+        view_func=create_blueprint_item,
+        methods=["POST"],
+    )
+    app.register_blueprint(blueprint, url_prefix="/bp")
+
+    class ItemsView(MethodView):
+        def post(self, query, json):
+            return [{"name": json.name, "limit": query.limit}]
+
+    ItemsView.post = _annotate_handler(ItemsView.post, query_model, payload_model)
+    ItemsView.post = spec.validate(resp=Response(HTTP_200=raw_list_model))(
+        ItemsView.post
+    )
+    app.add_url_rule(
+        "/view-items",
+        view_func=ItemsView.as_view("items_view"),
+        methods=["POST"],
+    )
+
+    with app.app_context():
+        _ = spec.spec
+    spec.register(app)
+
+    with app.test_client() as client:
+        yield FlaskAdapterApp(
+            client=client,
+            spec=spec,
+            route_handlers=(create_item, create_blueprint_item, ItemsView.post),
+            item_model=item_model,
+            raw_list_model=raw_list_model,
+        )
+
+
+@pytest.mark.parametrize("path", ["/items", "/bp/items", "/view-items"])
+def test_flask_model_adapter_validation_flow(flask_adapter_app, path):
+    response = flask_adapter_app.client.post(
+        f"{path}?limit=3",
+        json={"name": "demo"},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == [{"name": "demo", "limit": 3}]
+
+
+@pytest.mark.parametrize("path", ["/items", "/bp/items", "/view-items"])
+def test_flask_model_adapter_validation_error(flask_adapter_app, path):
+    response = flask_adapter_app.client.post(
+        f"{path}?limit=bad",
+        json={"name": "demo"},
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    errors = response.get_json()
+    assert isinstance(errors, list)
+    assert errors[0]["loc"] == ["limit"]
+    assert errors[0]["msg"]
+    assert errors[0]["type"]
+
+
+def test_flask_model_adapter_response_models_and_spec(flask_adapter_app):
+    expected_list_model = flask_adapter_app.spec.model_adapter.make_list_model(
+        flask_adapter_app.item_model
+    )
+
+    for handler in flask_adapter_app.route_handlers:
+        assert (
+            handler.resp.find_model(HTTPStatus.UNPROCESSABLE_ENTITY)
+            is flask_adapter_app.spec.model_adapter.validation_error
+        )
+
+        response_model = handler.resp.find_model(HTTPStatus.OK)
+        assert response_model is not flask_adapter_app.raw_list_model
+        assert get_model_key(response_model) == get_model_key(expected_list_model)
+
+    spec = flask_adapter_app.spec.spec
+    expected_response_ref = f"#/components/schemas/{get_model_key(expected_list_model)}"
+    validation_error = flask_adapter_app.spec.model_adapter.validation_error
+    validation_ref = f"#/components/schemas/{get_model_key(validation_error)}"
+
+    for path in ("/items", "/bp/items", "/view-items"):
+        responses = spec["paths"][path]["post"]["responses"]
+        ok_schema = responses[str(HTTPStatus.OK.value)]["content"]["application/json"][
+            "schema"
+        ]
+        validation_schema = responses[str(HTTPStatus.UNPROCESSABLE_ENTITY.value)][
+            "content"
+        ]["application/json"]["schema"]
+
+        assert ok_schema["$ref"] == expected_response_ref
+        assert validation_schema["$ref"] == validation_ref

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -2,6 +2,7 @@ import pytest
 
 from spectree.response import DEFAULT_CODE_DESC, Response
 from spectree.utils import get_model_key
+from tests.model_cases import SimpleModel
 
 
 class NormalClass:
@@ -35,7 +36,7 @@ def test_response_rejects_invalid_model(model_case):
 
 def test_init_response(model_case):
     adapter = model_case.adapter
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
 
     resp = Response("HTTP_200", HTTP_201=simple_model)
     resp.bind_model_adapter(adapter)
@@ -77,24 +78,26 @@ def test_response_add_model(model_case):
     resp = Response()
     resp.bind_model_adapter(model_case.adapter)
 
-    resp.add_model(201, model_case.simple_model)
+    simple_model = model_case.get_model(SimpleModel)
+    resp.add_model(201, simple_model)
 
-    assert resp.find_model(201) is model_case.simple_model
+    assert resp.find_model(201) is simple_model
 
 
 def test_response_find_model_requires_bound_adapter(model_case):
-    resp = Response(HTTP_200=model_case.simple_model)
+    simple_model = model_case.get_model(SimpleModel)
+    resp = Response(HTTP_200=simple_model)
 
     assert resp.find_model(200) is None
 
     resp.bind_model_adapter(model_case.adapter)
 
-    assert resp.find_model(200) is model_case.simple_model
+    assert resp.find_model(200) is simple_model
 
 
 def test_response_add_model_builds_only_new_model(monkeypatch, model_case):
     adapter = model_case.adapter
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
     list_model = model_case.list_of(simple_model)
 
     resp = Response(HTTP_200=list_model)
@@ -120,7 +123,7 @@ def test_response_add_model_builds_only_new_model(monkeypatch, model_case):
     "replace, expected_model_name",
     [
         pytest.param(True, "users_model", id="replace-existing-model"),
-        pytest.param(False, "simple_model", id="keep-existing-model"),
+        pytest.param(False, "simple", id="keep-existing-model"),
     ],
 )
 def test_response_add_model_when_model_already_exists(
@@ -130,26 +133,34 @@ def test_response_add_model_when_model_already_exists(
 ):
     resp = Response()
     resp.bind_model_adapter(model_case.adapter)
+    simple_model = model_case.get_model(SimpleModel)
+    users_model = model_case.get_model(list[SimpleModel], name="Users")
 
-    resp.add_model(201, model_case.simple_model)
-    resp.add_model(201, model_case.users_model, replace=replace)
+    resp.add_model(201, simple_model)
+    resp.add_model(201, users_model, replace=replace)
 
-    assert resp.find_model(201) is getattr(model_case, expected_model_name)
+    expected_models = {
+        "users_model": users_model,
+        "simple": simple_model,
+    }
+    assert resp.find_model(201) is expected_models[expected_model_name]
 
 
 def test_response_add_model_when_model_already_exists_before_bind(model_case):
     resp = Response()
+    simple_model = model_case.get_model(SimpleModel)
+    users_model = model_case.get_model(list[SimpleModel], name="Users")
 
-    resp.add_model(201, model_case.simple_model)
-    resp.add_model(201, model_case.users_model, replace=False)
+    resp.add_model(201, simple_model)
+    resp.add_model(201, users_model, replace=False)
     resp.bind_model_adapter(model_case.adapter)
 
-    assert resp.find_model(201) is model_case.simple_model
+    assert resp.find_model(201) is simple_model
 
 
 def test_response_spec(model_case):
     adapter = model_case.adapter
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
     validation_error = adapter.validation_error
 
     resp = Response(
@@ -180,7 +191,7 @@ def test_response_spec(model_case):
 
 
 def test_list_model(model_case):
-    simple_model = model_case.simple_model
+    simple_model = model_case.get_model(SimpleModel)
     list_model = model_case.list_of(simple_model)
 
     resp = Response(HTTP_200=list_model)

--- a/uv.lock
+++ b/uv.lock
@@ -1488,15 +1488,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -868,26 +868,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.3.13"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/59/0a279983f96bd5d538b4975f0a23121082aa3b8560b6649fdf61f8011b07/prek-0.3.13.tar.gz", hash = "sha256:c48586ee3708bfbf3df80121f55583e9a7d0fa166b08172c091fe5971e92a0ac", size = 444848, upload-time = "2026-05-05T18:07:09.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/01/1d2c238c6f226d75881cd7a5532e980f4d524babc3c034d16ad89e88b6e1/prek-0.4.1.tar.gz", hash = "sha256:622a8812bda87cf4ddcae2dab5ccecc55b88d70c677129dbe25e975d923179f0", size = 452606, upload-time = "2026-05-20T04:27:19.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/6a/9baa2bda21dccc2927e952416f6cc23a75eb99c9ed18837164ac2e4a5640/prek-0.3.13-py3-none-linux_armv6l.whl", hash = "sha256:b00d38f01235073c35aa5f48df57fefef45a6cec2ae0884d750345a2c7220370", size = 5506622, upload-time = "2026-05-05T18:06:53.091Z" },
-    { url = "https://files.pythonhosted.org/packages/56/77/d44b5d9bdca0879b865f8e47bf84cf5dc9e8b358d029e6d9b83d8809c116/prek-0.3.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0d89ac712c60e34d1550a606ad5fdfb8ad71d44ced8afa2fa5cbc106be4abd9e", size = 5878743, upload-time = "2026-05-05T18:07:23.164Z" },
-    { url = "https://files.pythonhosted.org/packages/08/cf/19e8525cde8b3aa12858aca434d1fa653ef3b152da5af11eafc857634dc2/prek-0.3.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f9b5265863d18b5be4ea094fdce4fd6ca61a8c89a70ee3d8ee153b3e0ed6b272", size = 5434909, upload-time = "2026-05-05T18:07:25.276Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9a/e5f97194782de4dab622ce09dafb3ebdd2ee4d354a83ac4def7ebeee236c/prek-0.3.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:64b59a1550780af2bba37297c704b17f81d8e9df6288af1fab4017938e33b1db", size = 5697536, upload-time = "2026-05-05T18:07:05.475Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/8c/e1f548ffc4b227e4c2b5a9b30f5978a7e0e6dad51305b97a2ba5b2a923e7/prek-0.3.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ce6cd8f114ba9bbdbe97422103fd886101949b1c42e588a7543c4436ead2020", size = 5428160, upload-time = "2026-05-05T18:07:01.489Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/44/abd919b00905a32d21dca2cec32c707860cf217da2431b62dd52684b310e/prek-0.3.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc03e924a24d8d961f56195853c8b206cb196be6db4ad8312125dae847d718ac", size = 5827275, upload-time = "2026-05-05T18:07:17.437Z" },
-    { url = "https://files.pythonhosted.org/packages/af/ed/cafd2b80d58a83faf8371c6543bd1475a2224242a3294da7f8582f6aa551/prek-0.3.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ca8c526a23873177fb3b92013500b08ef5f8bedc7263f9f3a44dd2f49645a26", size = 6710293, upload-time = "2026-05-05T18:07:10.663Z" },
-    { url = "https://files.pythonhosted.org/packages/35/09/52a4a27596b764173a34d74db09356b30faaacb4a1075b75adbc036a0008/prek-0.3.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5bbb175478438a871e3281d2c3c3f067288af73ad81707a9bdebfd769766c7d", size = 6096556, upload-time = "2026-05-05T18:07:19.46Z" },
-    { url = "https://files.pythonhosted.org/packages/63/60/80f61729ce6498815d46d5580cf76da2c157c9b6494046183682441a0ea3/prek-0.3.13-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a65327a014d838341af757dfc05a706d10e8e33f039bc32bb3dbe2fa21c440c0", size = 5693267, upload-time = "2026-05-05T18:07:03.66Z" },
-    { url = "https://files.pythonhosted.org/packages/36/9d/c7a663fe70676ffab2e0c6c9a71997a3ccd002ed5bc60b7422a937911af0/prek-0.3.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b6a200843a36a5b0c41764ce7639ccb3471d48b097f1c5e3fc8f034219b42626", size = 5532865, upload-time = "2026-05-05T18:07:15.237Z" },
-    { url = "https://files.pythonhosted.org/packages/32/68/506ef5a235536030e16f61e7210474554f6e05f845f27df5877d2dbb1a06/prek-0.3.13-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bdacaad8f35f343e063d251211fe34db1de9e5cc591795361ad69a6485202258", size = 5395951, upload-time = "2026-05-05T18:06:55.183Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/00/22d7c6db7f43b58f7d015913c12660c9bbc82751cff6cfd8c31993cf30eb/prek-0.3.13-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f00328f1c520d8fefb910ab0d3c6764ee330d227952baa19b7e3de7242bd8b3b", size = 5681195, upload-time = "2026-05-05T18:07:12.804Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e3/fdf9882238796914ddaf11381a9083b374980156200a953324f6c795f34d/prek-0.3.13-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e5530a867bcf5b172b7513a64e71b06a337d1d184696227ae953845867376b8d", size = 6212085, upload-time = "2026-05-05T18:07:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/1d/528759931344b5c7103085798f5fa2e86d27d9410b753a6bcbe7726aa8ba/prek-0.3.13-py3-none-win32.whl", hash = "sha256:326fac2bdce00074ce6c5046b861d310638aee2b9de1ed241ba7eb32bdc83898", size = 5199566, upload-time = "2026-05-05T18:07:21.416Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d0/8715ee837c73314a02767d20652cc312d1b6ff6733fa00f52de2b648bc3a/prek-0.3.13-py3-none-win_amd64.whl", hash = "sha256:841049f89f5ec9f4035299283d11e566ac5a068e3742ead1055ea04f886831fc", size = 5589599, upload-time = "2026-05-05T18:06:57.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/cf/0af0b15be0ebd82f7e50adee149b05a73533d78cb1b97cb889f0647ebffe/prek-0.3.13-py3-none-win_arm64.whl", hash = "sha256:a9fd74e0aec550c6b8d41076fdcdd6ff121cd7d94d743c1338bd794784e3c775", size = 5419029, upload-time = "2026-05-05T18:06:59.645Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ca/0274343faf2672d649b1e648053d3cb48fdfef7a390b43713d95880ebb67/prek-0.4.1-py3-none-linux_armv6l.whl", hash = "sha256:10e7e78ffe65dfba7d687a8c71b2f473554d1ba60f43c742105da4c0030feed9", size = 5515584, upload-time = "2026-05-20T04:27:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4e/6a067f530194a6e4141c36463eece92356dfd7f924ffe0cbf456bdca723b/prek-0.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b25807e0aa57d2118747e127b58e7a1bf41d5d7b3323f5f3f1f3cb10031245cc", size = 5878925, upload-time = "2026-05-20T04:27:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/3d/a334c0f5b88fadca888eadfc1fb3d7f1dc8358b1a534d0987339ecb8eb92/prek-0.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:efa95331c4c171a867c0064c19d8a4abc94a1c1c920c8b8092f2d7d87f4b90a8", size = 5440994, upload-time = "2026-05-20T04:27:40.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3b/fa6eb635495c3576e65d7f42a48b9fdf4926dd052010df506ed98e9f9680/prek-0.4.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2d1805123ab5d730629de588bf319ea39e7078b589b3288c95740f1b4780a1d4", size = 5692369, upload-time = "2026-05-20T04:27:23.184Z" },
+    { url = "https://files.pythonhosted.org/packages/70/cb/9d9078723b3facb40289444332ca82bf38c0e1db3b5a907af461aba12324/prek-0.4.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:051c442b570b53756225410240577bee1aeace6be52955dfacf45a9783223b36", size = 5430031, upload-time = "2026-05-20T04:27:27.475Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/96/2d8cc6b5425215cd0b610f1dcef3f6f0f23db2a2b85f1a6fca43b7e7fe24/prek-0.4.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76663998827a2cbc94f5e209319809655489b5bd1f8e70568a623372e80253f0", size = 5834244, upload-time = "2026-05-20T04:27:44.229Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e0/cce02f3ade48a6d4bffb25e5f0ac28d10928263b0a4f53ecc72954957f4e/prek-0.4.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2ab3460641762edf128b1ec8e833ce7e9ae015d1268a894560cb90d3393a7527", size = 6711903, upload-time = "2026-05-20T04:27:34.128Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/ccd581b6222277a2aa095530844d5bb76db4547042f05a9cb649476bf904/prek-0.4.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e69a9c02ead38706a5d2a4ae209dccba08ccb5d0026e1d08e723c66ab964750", size = 6084138, upload-time = "2026-05-20T04:27:46.549Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b7/6164a7dc6bb4796cfc19445be798302cc7625b62e2bec89ffb4272d7f983/prek-0.4.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:dc744fedf98df8a00a9e3bcd629b163fee5e9f9e22bce66029d9945241586165", size = 5698950, upload-time = "2026-05-20T04:27:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/96/40/8151d6445a0f41ad60e979db39d8b0c6b074aad919cf5c73233281f0dff1/prek-0.4.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c0877e82c52359d655fe1072b3a5228639184d1d5f03c6803b6530cd6da1ef20", size = 5538662, upload-time = "2026-05-20T04:27:15.045Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/1f9892a45bb2dc8a3b4b89eb08f5de1cf745fcd7df9e535463ba4d41cebe/prek-0.4.1-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:60928d1dad45ff3e491d3083a50643cc213aa2d54f1dbd8d702d7193773c020e", size = 5406581, upload-time = "2026-05-20T04:27:21.101Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b8/94ddac155b502859e4dc7943db99fa7fffecfa3878a2ef11726a8e72fad0/prek-0.4.1-py3-none-musllinux_1_1_i686.whl", hash = "sha256:17ffa9d8dd40791b9b99cafe558c5cc28e78e5be57607b280b15f0dab90264e9", size = 5688880, upload-time = "2026-05-20T04:27:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/fd/e93d3853d1bdc06b281fff2aaf4106e19610fe5187c67c9ff13195f2df59/prek-0.4.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:cdf4503a240369f66321213d9c4bc6f925014b64ff7121de9e9920c9b9838ce2", size = 6203536, upload-time = "2026-05-20T04:27:42.366Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/760969d6bfc77e3eba04f6c3801c81076e96a908a6c277c142a4b0f31f4e/prek-0.4.1-py3-none-win32.whl", hash = "sha256:7c515492ef3585e6bcd7b83f1bb1cb131038abc88ed2c843de1e4c3ceb865b19", size = 5208995, upload-time = "2026-05-20T04:27:38.331Z" },
+    { url = "https://files.pythonhosted.org/packages/89/12/d43daf290a73dbc3e1a3eabb9077e45df661923949bee045de67cbe82524/prek-0.4.1-py3-none-win_amd64.whl", hash = "sha256:8fa707971465d8ad021c907e43691aad7bb98942943e61e294ece5f95d9fbc78", size = 5591734, upload-time = "2026-05-20T04:27:12.744Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/36/2ab7647fe1e84bba2baae7f04de241197eed62683fb3085e164de266d111/prek-0.4.1-py3-none-win_arm64.whl", hash = "sha256:5b4a348537924b20e208cbd87ef58e96ec37d691c5bec2969209c40de0ecf72e", size = 5423147, upload-time = "2026-05-20T04:27:17.023Z" },
 ]
 
 [[package]]
@@ -1188,32 +1188,32 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
 name = "shibuya"
-version = "2026.1.9"
+version = "2026.5.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments-styles" },
@@ -1221,9 +1221,9 @@ dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/b94cb04adbb984973fe83fd670dd066514610241d829723f678366e691d2/shibuya-2026.1.9.tar.gz", hash = "sha256:b389f10fd9c07b048e940f32d1e1ac096a2d49736389173ac771b37a10b51fdf", size = 86002, upload-time = "2026-01-09T02:19:14.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/eb/9de0c2a5691c96e77823ec0582b34ab1f38830530bcb12103ce8d880c205/shibuya-2026.5.19.tar.gz", hash = "sha256:f39e012e945ecb93f8aeaeab48e7bfaa204d570fe86796034a1f01fe4f1a3709", size = 86198, upload-time = "2026-05-19T11:38:13.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/ae/06d7dfc5633c7250fefc61fd624990aa2c37e3495c08a2f23968b1acb23e/shibuya-2026.1.9-py3-none-any.whl", hash = "sha256:b58a3cc6e5619c71d00fcf0be4a3060c87040c2a62a1b3f1a93a6a41ca8eaf45", size = 103389, upload-time = "2026-01-09T02:19:12.798Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/82/482a2e77a79a8ebc2f40d8e38cc186f2a72f2bf003c8e7395c3eefb9bc3f/shibuya-2026.5.19-py3-none-any.whl", hash = "sha256:7e94f6d5d9e269510138f4742c993c875beaa32344bf5fc55d104bc89e62028e", size = 103556, upload-time = "2026-05-19T11:38:11.71Z" },
 ]
 
 [[package]]
@@ -1510,14 +1510,14 @@ full = [
 
 [[package]]
 name = "syrupy"
-version = "5.1.0"
+version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/7e/a4793801683d32132d9683be8364e93f6bca2f277bfbe81647eba46b8cfd/syrupy-5.2.0.tar.gz", hash = "sha256:0e6b7abf1e04f060f6c797bed8bca96f2468954168328041e02634a68fc11ff0", size = 50223, upload-time = "2026-05-16T21:11:37.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/18/dc99a152bea18a898a8ac387bfeb9ec0829e0f5bed11cfec2e2ca189c5a2/syrupy-5.2.0-py3-none-any.whl", hash = "sha256:798cb493a6e20f4839e58ea8f10eb1b0d85684c676442f79786e219bf32618e6", size = 51828, upload-time = "2026-05-16T21:11:34.984Z" },
 ]
 
 [[package]]
@@ -1619,16 +1619,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.46.0"
+version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adapters will convert from the source dataclass class type to their own class type. This allows us to maintain a single-source-of-truth with dataclass, and get the dedicated class type for different adapters.

Also refact base plugin and part of the flask plugin.