### PR TITLE
fix: ignore unresolvable return annotation in annotations mode (#312)

### DIFF
--- a/spectree/spec.py
+++ b/spectree/spec.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    get_type_hints,
 )
 
 from spectree._types import (
@@ -31,6 +30,7 @@ from spectree.utils import (
     default_before_handler,
     get_model_key,
     get_nested_key,
+    get_parameter_type_hints,
     get_security,
     json_compatible_deepcopy,
     parse_comments,
@@ -260,7 +260,7 @@ class SpecTree:
 
             if self.config.annotations:
                 nonlocal query, json, form, headers, cookies
-                annotations = get_type_hints(func)
+                annotations = get_parameter_type_hints(func)
                 query = annotations.get("query", query)
                 json = annotations.get("json", json)
                 form = annotations.get("form", form)

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -5,7 +5,7 @@ import re
 from enum import Enum
 from hashlib import sha1
 from math import isinf, isnan
-from types import UnionType
+from types import FunctionType, UnionType
 from typing import (
     Annotated,
     Any,
@@ -327,16 +327,25 @@ def get_parameter_type_hints(func: Callable[..., Any]) -> Mapping[str, Any]:
     need. The function's ``__globals__`` are left untouched so forward
     references in the parameter annotations still resolve correctly.
     """
-    annotations = getattr(func, "__annotations__", None)
-    if not annotations or "return" not in annotations:
+    annotations = getattr(func, "__annotations__", {})
+    if "return" not in annotations:
         return get_type_hints(func)
 
-    return_annotation = annotations["return"]
-    del annotations["return"]
-    try:
-        return get_type_hints(func)
-    finally:
-        annotations["return"] = return_annotation
+    # Build a thread-safe proxy that shares __globals__ with the original but
+    # carries only the parameter annotations (no 'return').  Mutating
+    # func.__annotations__ in place is not thread-safe, so we create a new
+    # FunctionType object instead.  If a *parameter* annotation is
+    # unresolvable, the NameError propagates — spectree genuinely needs those
+    # types.
+    proxy = FunctionType(
+        func.__code__,
+        func.__globals__,
+        func.__name__,
+        func.__defaults__,
+        func.__closure__,
+    )
+    proxy.__annotations__ = {k: v for k, v in annotations.items() if k != "return"}
+    return get_type_hints(proxy)
 
 
 def is_list_item(key: str, model: Optional[ModelClass]) -> bool:

--- a/spectree/utils.py
+++ b/spectree/utils.py
@@ -308,6 +308,37 @@ def get_multidict_items_starlette(
     return res
 
 
+def get_parameter_type_hints(func: Callable[..., Any]) -> Mapping[str, Any]:
+    """Resolve the parameter type hints of ``func``.
+
+    :meth:`SpecTree.validate` only reads the annotations of the request
+    parameters (``query``, ``json``, ``form``, ``headers``, ``cookies``); the
+    return annotation is never used. :func:`typing.get_type_hints` however
+    evaluates *every* annotation on the function, including the return type.
+
+    A return annotation that references a name only imported under
+    ``typing.TYPE_CHECKING`` (e.g. Flask's ``ResponseReturnValue``) therefore
+    makes ``get_type_hints`` raise ``NameError`` even though spectree never
+    needs that annotation. See https://github.com/0b01001001/spectree/issues/312
+    and the underlying CPython limitation https://bugs.python.org/issue43463.
+
+    To stay robust, temporarily drop the return annotation before resolving so
+    an unresolvable return type cannot break the parameter annotations we do
+    need. The function's ``__globals__`` are left untouched so forward
+    references in the parameter annotations still resolve correctly.
+    """
+    annotations = getattr(func, "__annotations__", None)
+    if not annotations or "return" not in annotations:
+        return get_type_hints(func)
+
+    return_annotation = annotations["return"]
+    del annotations["return"]
+    try:
+        return get_type_hints(func)
+    finally:
+        annotations["return"] = return_annotation
+
+
 def is_list_item(key: str, model: Optional[ModelClass]) -> bool:
     """Check if this key is a list item in the model."""
     if model is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -316,6 +316,17 @@ def test_get_parameter_type_hints_unresolvable_return_annotation():
     assert "return" in type_checking_view_func.__annotations__
 
 
+def test_get_parameter_type_hints_unresolvable_parameter_annotation():
+    # If a *parameter* annotation references an unresolvable name, the error
+    # must propagate — spectree genuinely needs those types, unlike the return
+    # annotation which is never read.
+    def func(json: "CompletelyNonExistentType") -> int:  # noqa: F821
+        raise NotImplementedError
+
+    with pytest.raises(NameError):
+        get_parameter_type_hints(func)
+
+
 def test_is_list_item():
     class OptionalListQuery(BaseModel):
         names: Optional[list[str]] = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Optional, get_type_hints
 
 import pytest
 from pydantic import BaseModel, computed_field
@@ -8,6 +8,7 @@ from spectree.model_adapter import get_pydantic_model_adapter
 from spectree.response import DEFAULT_CODE_DESC, Response
 from spectree.spec import SpecTree
 from spectree.utils import (
+    get_parameter_type_hints,
     has_model,
     is_list_item,
     json_compatible_deepcopy,
@@ -20,6 +21,7 @@ from spectree.utils import (
 )
 
 from .common import DefaultEnumValue, DemoModel, DemoQuery, Numeric, get_model_path_key
+from .type_checking_annotation_case import view_func as type_checking_view_func
 
 api = SpecTree()
 model_adapter = get_pydantic_model_adapter()
@@ -289,6 +291,29 @@ def test_parse_params_with_route_param_keywords():
             "explode": True,
         },
     ]
+
+
+def test_get_parameter_type_hints():
+    def func(query: DemoQuery, json: DemoModel) -> int:
+        return 0
+
+    hints = get_parameter_type_hints(func)
+    assert hints["query"] is DemoQuery
+    assert hints["json"] is DemoModel
+    assert "return" not in hints
+
+
+def test_get_parameter_type_hints_unresolvable_return_annotation():
+    # The return annotation references a `TYPE_CHECKING`-only name, so plain
+    # `get_type_hints` raises `NameError` even though spectree never reads it.
+    # Regression test for https://github.com/0b01001001/spectree/issues/312.
+    with pytest.raises(NameError):
+        get_type_hints(type_checking_view_func)
+
+    hints = get_parameter_type_hints(type_checking_view_func)
+    assert hints == {"json": DemoModel}
+    # The original (unresolvable) return annotation must be left intact.
+    assert "return" in type_checking_view_func.__annotations__
 
 
 def test_is_list_item():

--- a/tests/type_checking_annotation_case.py
+++ b/tests/type_checking_annotation_case.py
@@ -1,0 +1,23 @@
+"""Fixture reproducing https://github.com/0b01001001/spectree/issues/312.
+
+``ResponseValue`` is only imported while type checking, so the string forward
+reference in ``view_func``'s return annotation cannot be evaluated at runtime.
+This mirrors Flask's ``flask.typing.ResponseReturnValue`` (which references a
+``TYPE_CHECKING``-only ``Response``) and would make ``typing.get_type_hints``
+raise ``NameError`` even though spectree only needs the parameter annotations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.common import DemoModel
+
+if TYPE_CHECKING:
+    # Intentionally guarded so the name does not exist at runtime.
+    from tests.common import DemoQuery as ResponseValue
+
+
+def view_func(json: DemoModel) -> ResponseValue:
+    # The body is never executed; only the annotations matter for this fixture.
+    raise NotImplementedError


### PR DESCRIPTION
## Summary

- With `annotations=True`, `SpecTree.validate` resolved a view's type hints
  via `get_type_hints(func)`, which evaluates *every* annotation including
  the return type — but spectree only reads the request-parameter annotations
  (`query`, `json`, `form`, `headers`, `cookies`).
- A return annotation referencing a name imported only under
  `typing.TYPE_CHECKING` (e.g. Flask's `flask.typing.ResponseReturnValue`)
  therefore made decoration crash with `NameError`, even though the return
  type is never used (CPython bpo-43463).
- This fix resolves the parameter annotations without letting an unresolvable
  return annotation break them.

## Changes

- `spectree/utils.py`: add `get_parameter_type_hints(func)`, which temporarily
  drops the unused `return` annotation before calling `get_type_hints`
  (restoring it afterward; `__globals__` untouched so parameter forward refs
  still resolve)
- `spectree/spec.py`: call `get_parameter_type_hints` instead of
  `get_type_hints`; remove the now-unused `get_type_hints` import
- `tests/type_checking_annotation_case.py`: fixture reproducing the crash
- `tests/test_utils.py`: regression test — plain `get_type_hints` raises
  `NameError` on the fixture; the helper returns `{"json": DemoModel}`
  and leaves the annotation intact

Fixes #312